### PR TITLE
Remove NAME variable from app paths

### DIFF
--- a/AppCleaner/AppCleaner.pkg.recipe
+++ b/AppCleaner/AppCleaner.pkg.recipe
@@ -52,7 +52,7 @@
 				<key>Arguments</key>
 				<dict>
 					<key>input_path</key>
-					<string>%pkgroot%/Applications/%NAME%.app</string>
+					<string>%pkgroot%/Applications/AppCleaner.app</string>
 					<key>requirement</key>
 					<string>anchor apple generic and identifier "net.freemacsoft.AppCleaner" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = X85ZX835W9)</string>
 				</dict>
@@ -63,7 +63,7 @@
 				<key>Arguments</key>
 				<dict>
 					<key>input_plist_path</key>
-					<string>%pkgroot%/Applications/%NAME%.app/Contents/Info.plist</string>
+					<string>%pkgroot%/Applications/AppCleaner.app/Contents/Info.plist</string>
 					<key>plist_version_key</key>
 					<string>CFBundleShortVersionString</string>
 				</dict>

--- a/JD-GUI/JD-GUI.pkg.recipe
+++ b/JD-GUI/JD-GUI.pkg.recipe
@@ -67,7 +67,7 @@
 					<key>source_path</key>
 					<string>%found_filename%</string>
 					<key>destination_path</key>
-					<string>%pkgroot%/Applications/%NAME%.app</string>
+					<string>%pkgroot%/Applications/JD-GUI.app</string>
 				</dict>
 			</dict>
 			<dict>


### PR DESCRIPTION
Because variables can be overridden, it's a good idea to make sure that the recipe will still work even if a non-default variables used. One issue that would prevent recipes from running is using a `NAME` variable in paths that should be hard-coded (e.g. `/Applications/Foo.app`).

This PR removes the `NAME` variable from all file paths and replaces it with the actual app name, which should make the recipe more resilient for overrides.