### PR TITLE
Adjust PkgCreator arguments

### DIFF
--- a/AppCleaner/AppCleaner.pkg.recipe
+++ b/AppCleaner/AppCleaner.pkg.recipe
@@ -75,10 +75,10 @@
 				<string>PkgCreator</string>
 				<key>Arguments</key>
 				<dict>
-					<key>pkgname</key>
-					<string>%NAME%-%version%</string>
 					<key>pkg_request</key>
 					<dict>
+						<key>pkgname</key>
+						<string>%NAME%-%version%</string>
 						<key>pkgdir</key>
 						<string>%RECIPE_CACHE_DIR%</string>
 						<key>id</key>

--- a/Boostnote/Boostnote.pkg.recipe
+++ b/Boostnote/Boostnote.pkg.recipe
@@ -75,10 +75,10 @@
 			<string>PkgCreator</string>
 			<key>Arguments</key>
 			<dict>
-				<key>pkgname</key>
-				<string>%NAME%-%version%</string>
 				<key>pkg_request</key>
 				<dict>
+					<key>pkgname</key>
+					<string>%NAME%-%version%</string>
 					<key>pkgdir</key>
 					<string>%RECIPE_CACHE_DIR%</string>
 					<key>id</key>

--- a/JD-GUI/JD-GUI.pkg.recipe
+++ b/JD-GUI/JD-GUI.pkg.recipe
@@ -91,10 +91,10 @@
 				<string>PkgCreator</string>
 				<key>Arguments</key>
 				<dict>
-					<key>pkgname</key>
-					<string>%NAME%-%version%</string>
 					<key>pkg_request</key>
 					<dict>
+						<key>pkgname</key>
+						<string>%NAME%-%version%</string>
 						<key>pkgdir</key>
 						<string>%RECIPE_CACHE_DIR%</string>
 						<key>id</key>

--- a/Miller/Miller.pkg.recipe
+++ b/Miller/Miller.pkg.recipe
@@ -53,10 +53,10 @@
 			<string>PkgCreator</string>
 			<key>Arguments</key>
 			<dict>
-				<key>pkgname</key>
-				<string>%NAME%-%version%</string>
 				<key>pkg_request</key>
 				<dict>
+					<key>pkgname</key>
+					<string>%NAME%-%version%</string>
 					<key>pkgdir</key>
 					<string>%RECIPE_CACHE_DIR%</string>
 					<key>id</key>

--- a/ecs-cli/ecs-cli.pkg.recipe
+++ b/ecs-cli/ecs-cli.pkg.recipe
@@ -53,10 +53,10 @@
 			<string>PkgCreator</string>
 			<key>Arguments</key>
 			<dict>
-				<key>pkgname</key>
-				<string>%NAME%</string>
 				<key>pkg_request</key>
 				<dict>
+					<key>pkgname</key>
+					<string>%NAME%</string>
 					<key>pkgdir</key>
 					<string>%RECIPE_CACHE_DIR%</string>
 					<key>id</key>


### PR DESCRIPTION
`pkgname` is [intended](https://github.com/autopkg/autopkg/blob/e36d5cba2823dbdfcb69a41a38b1aef9fb76121c/Code/autopkgserver/autopkgserver#L47) to be in the `pkg_request` dictionary, not as a standalone argument for [PkgCreator](https://github.com/autopkg/autopkg/wiki/Processor-PkgCreator).