### PR TITLE
Remove unused BUNDLE_ID input var

### DIFF
--- a/Brave/Brave.pkg.recipe
+++ b/Brave/Brave.pkg.recipe
@@ -1,32 +1,30 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
+<dict>
+	<key>Comment</key>
+	<string>Created with Recipe Robot v1.0.5 (https://github.com/homebysix/recipe-robot)</string>
+	<key>Description</key>
+	<string>Downloads the latest version of Brave and creates a package.</string>
+	<key>Identifier</key>
+	<string>com.github.fishd72.pkg.brave</string>
+	<key>Input</key>
 	<dict>
-		<key>Comment</key>
-		<string>Created with Recipe Robot v1.0.5 (https://github.com/homebysix/recipe-robot)</string>
-		<key>Description</key>
-		<string>Downloads the latest version of Brave and creates a package.</string>
-		<key>Identifier</key>
-		<string>com.github.fishd72.pkg.brave</string>
-		<key>Input</key>
-		<dict>
-			<key>APP_FILENAME</key>
-			<string>Brave</string>
-			<key>BUNDLE_ID</key>
-			<string>com.electron.brave</string>
-			<key>NAME</key>
-			<string>Brave</string>
-		</dict>
-		<key>MinimumVersion</key>
-		<string>1.0.0</string>
-		<key>ParentRecipe</key>
-		<string>com.github.apettinen.download.brave</string>
-		<key>Process</key>
-		<array>
-			<dict>
-				<key>Processor</key>
-				<string>AppPkgCreator</string>
-			</dict>
-		</array>
+		<key>APP_FILENAME</key>
+		<string>Brave</string>
+		<key>NAME</key>
+		<string>Brave</string>
 	</dict>
+	<key>MinimumVersion</key>
+	<string>1.0.0</string>
+	<key>ParentRecipe</key>
+	<string>com.github.apettinen.download.brave</string>
+	<key>Process</key>
+	<array>
+		<dict>
+			<key>Processor</key>
+			<string>AppPkgCreator</string>
+		</dict>
+	</array>
+</dict>
 </plist>

--- a/Curse, Inc./Twitch.pkg.recipe
+++ b/Curse, Inc./Twitch.pkg.recipe
@@ -10,8 +10,6 @@
 	<string>com.github.fishd72.pkg.Twitch</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>com.twitch.desktop</string>
 		<key>NAME</key>
 		<string>Twitch</string>
 	</dict>

--- a/DockerEdge/DockerEdge.pkg.recipe
+++ b/DockerEdge/DockerEdge.pkg.recipe
@@ -1,35 +1,33 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
+<dict>
+	<key>Comment</key>
+	<string>Created with Recipe Robot v1.0.5 (https://github.com/homebysix/recipe-robot)</string>
+	<key>Description</key>
+	<string>Downloads the latest version of Docker Edge and creates a package.</string>
+	<key>Identifier</key>
+	<string>com.github.fishd72.pkg.DockerEdge</string>
+	<key>Input</key>
 	<dict>
-		<key>Comment</key>
-		<string>Created with Recipe Robot v1.0.5 (https://github.com/homebysix/recipe-robot)</string>
-		<key>Description</key>
-		<string>Downloads the latest version of Docker Edge and creates a package.</string>
-		<key>Identifier</key>
-		<string>com.github.fishd72.pkg.DockerEdge</string>
-		<key>Input</key>
-		<dict>
-			<key>BUNDLE_ID</key>
-			<string>com.docker.docker</string>
-			<key>NAME</key>
-			<string>Docker</string>
-		</dict>
-		<key>MinimumVersion</key>
-		<string>1.0.0</string>
-		<key>ParentRecipe</key>
-		<string>com.github.fishd72.download.DockerEdge</string>
-		<key>Process</key>
-		<array>
-			<dict>
-				<key>Arguments</key>
-				<dict>
-					<key>pkg_path</key>
-					<string>%RECIPE_CACHE_DIR%/%NAME%-Edge-%version%.pkg</string>
-				</dict>
-				<key>Processor</key>
-				<string>AppPkgCreator</string>
-			</dict>
-		</array>
+		<key>NAME</key>
+		<string>Docker</string>
 	</dict>
+	<key>MinimumVersion</key>
+	<string>1.0.0</string>
+	<key>ParentRecipe</key>
+	<string>com.github.fishd72.download.DockerEdge</string>
+	<key>Process</key>
+	<array>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>pkg_path</key>
+				<string>%RECIPE_CACHE_DIR%/%NAME%-Edge-%version%.pkg</string>
+			</dict>
+			<key>Processor</key>
+			<string>AppPkgCreator</string>
+		</dict>
+	</array>
+</dict>
 </plist>

--- a/DrawIO/DrawIO.pkg.recipe
+++ b/DrawIO/DrawIO.pkg.recipe
@@ -1,30 +1,28 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
+<dict>
+	<key>Description</key>
+	<string>Downloads the latest version of Draw.io and creates a package.</string>
+	<key>Identifier</key>
+	<string>com.github.fishd72.pkg.DrawIO</string>
+	<key>Input</key>
 	<dict>
-		<key>Description</key>
-		<string>Downloads the latest version of Draw.io and creates a package.</string>
-		<key>Identifier</key>
-		<string>com.github.fishd72.pkg.DrawIO</string>
-		<key>Input</key>
-		<dict>
-			<key>APP_FILENAME</key>
-			<string>draw.io</string>
-			<key>BUNDLE_ID</key>
-			<string>com.jgraph.drawio.desktop</string>
-			<key>NAME</key>
-			<string>draw.io</string>
-		</dict>
-		<key>MinimumVersion</key>
-		<string>1.0.0</string>
-		<key>ParentRecipe</key>
-		<string>com.github.michalmmac.download.draw.io</string>
-		<key>Process</key>
-		<array>
-			<dict>
-				<key>Processor</key>
-				<string>AppPkgCreator</string>
-			</dict>
-		</array>
+		<key>APP_FILENAME</key>
+		<string>draw.io</string>
+		<key>NAME</key>
+		<string>draw.io</string>
 	</dict>
+	<key>MinimumVersion</key>
+	<string>1.0.0</string>
+	<key>ParentRecipe</key>
+	<string>com.github.michalmmac.download.draw.io</string>
+	<key>Process</key>
+	<array>
+		<dict>
+			<key>Processor</key>
+			<string>AppPkgCreator</string>
+		</dict>
+	</array>
+</dict>
 </plist>

--- a/Emacs/EmacsForOSX.pkg.recipe
+++ b/Emacs/EmacsForOSX.pkg.recipe
@@ -1,28 +1,26 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
+<dict>
+	<key>Identifier</key>
+	<string>com.github.fishd72.pkg.EmacsForOSX</string>
+	<key>Input</key>
 	<dict>
-		<key>Identifier</key>
-		<string>com.github.fishd72.pkg.EmacsForOSX</string>
-		<key>Input</key>
-		<dict>
-			<key>APP_FILENAME</key>
-			<string>Emacs</string>
-			<key>BUNDLE_ID</key>
-			<string>org.gnu.Emacs</string>
-			<key>NAME</key>
-			<string>Emacs</string>
-		</dict>
-		<key>MinimumVersion</key>
-		<string>1.0.0</string>
-		<key>ParentRecipe</key>
-		<string>com.github.48kRAM.autopkg.download.emacsformacosx</string>
-		<key>Process</key>
-		<array>
-			<dict>
-				<key>Processor</key>
-				<string>AppPkgCreator</string>
-			</dict>
-		</array>
+		<key>APP_FILENAME</key>
+		<string>Emacs</string>
+		<key>NAME</key>
+		<string>Emacs</string>
 	</dict>
+	<key>MinimumVersion</key>
+	<string>1.0.0</string>
+	<key>ParentRecipe</key>
+	<string>com.github.48kRAM.autopkg.download.emacsformacosx</string>
+	<key>Process</key>
+	<array>
+		<dict>
+			<key>Processor</key>
+			<string>AppPkgCreator</string>
+		</dict>
+	</array>
+</dict>
 </plist>

--- a/Etcher/Etcher.pkg.recipe
+++ b/Etcher/Etcher.pkg.recipe
@@ -12,8 +12,6 @@
 	<dict>
 		<key>APP_FILENAME</key>
 		<string>balenaEtcher</string>
-		<key>BUNDLE_ID</key>
-		<string>io.balena.Etcher</string>
 		<key>NAME</key>
 		<string>balenaEtcher</string>
 	</dict>

--- a/Freeplane/Freeplane.pkg.recipe
+++ b/Freeplane/Freeplane.pkg.recipe
@@ -1,33 +1,31 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
+<dict>
+	<key>Description</key>
+	<string>Downloads the latest version of Freeplane and creates a package.</string>
+	<key>Identifier</key>
+	<string>com.github.fishd72.pkg.Freeplane</string>
+	<key>Input</key>
 	<dict>
-		<key>Description</key>
-		<string>Downloads the latest version of Freeplane and creates a package.</string>
-		<key>Identifier</key>
-		<string>com.github.fishd72.pkg.Freeplane</string>
-		<key>Input</key>
-		<dict>
-			<key>BUNDLE_ID</key>
-			<string>org.freeplane.core</string>
-			<key>NAME</key>
-			<string>Freeplane</string>
-		</dict>
-		<key>MinimumVersion</key>
-		<string>1.0.0</string>
-		<key>ParentRecipe</key>
-		<string>com.github.fishd72.download.Freeplane</string>
-		<key>Process</key>
-		<array>
-			<dict>
-				<key>Arguments</key>
-				<dict>
-					<key>pkg_path</key>
-					<string>%RECIPE_CACHE_DIR%/%NAME%-%version%.pkg</string>
-				</dict>
-				<key>Processor</key>
-				<string>AppPkgCreator</string>
-			</dict>
-		</array>
+		<key>NAME</key>
+		<string>Freeplane</string>
 	</dict>
+	<key>MinimumVersion</key>
+	<string>1.0.0</string>
+	<key>ParentRecipe</key>
+	<string>com.github.fishd72.download.Freeplane</string>
+	<key>Process</key>
+	<array>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>pkg_path</key>
+				<string>%RECIPE_CACHE_DIR%/%NAME%-%version%.pkg</string>
+			</dict>
+			<key>Processor</key>
+			<string>AppPkgCreator</string>
+		</dict>
+	</array>
+</dict>
 </plist>

--- a/Ghost/Ghost.pkg.recipe
+++ b/Ghost/Ghost.pkg.recipe
@@ -10,8 +10,6 @@
 	<string>com.github.fishd72.pkg.Ghost</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>com.electron.ghost</string>
 		<key>NAME</key>
 		<string>ghost-desktop</string>
 	</dict>

--- a/GoogleChromeCanary/GoogleChromeCanary.pkg.recipe
+++ b/GoogleChromeCanary/GoogleChromeCanary.pkg.recipe
@@ -1,32 +1,30 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
+<dict>
+	<key>Comment</key>
+	<string>Created with Recipe Robot v1.0.5 (https://github.com/homebysix/recipe-robot)</string>
+	<key>Description</key>
+	<string>Downloads the latest version of Chrome Canary and creates a package.</string>
+	<key>Identifier</key>
+	<string>com.github.fishd72.pkg.Chrome</string>
+	<key>Input</key>
 	<dict>
-		<key>Comment</key>
-		<string>Created with Recipe Robot v1.0.5 (https://github.com/homebysix/recipe-robot)</string>
-		<key>Description</key>
-		<string>Downloads the latest version of Chrome Canary and creates a package.</string>
-		<key>Identifier</key>
-		<string>com.github.fishd72.pkg.Chrome</string>
-		<key>Input</key>
-		<dict>
-			<key>APP_FILENAME</key>
-			<string>Google Chrome Canary</string>
-			<key>BUNDLE_ID</key>
-			<string>com.google.Chrome.canary</string>
-			<key>NAME</key>
-			<string>Chrome</string>
-		</dict>
-		<key>MinimumVersion</key>
-		<string>1.0.0</string>
-		<key>ParentRecipe</key>
-		<string>com.github.foigus.download.googlechromecanary</string>
-		<key>Process</key>
-		<array>
-			<dict>
-				<key>Processor</key>
-				<string>AppPkgCreator</string>
-			</dict>
-		</array>
+		<key>APP_FILENAME</key>
+		<string>Google Chrome Canary</string>
+		<key>NAME</key>
+		<string>Chrome</string>
 	</dict>
+	<key>MinimumVersion</key>
+	<string>1.0.0</string>
+	<key>ParentRecipe</key>
+	<string>com.github.foigus.download.googlechromecanary</string>
+	<key>Process</key>
+	<array>
+		<dict>
+			<key>Processor</key>
+			<string>AppPkgCreator</string>
+		</dict>
+	</array>
+</dict>
 </plist>

--- a/HexFiend/HexFiend.pkg.recipe
+++ b/HexFiend/HexFiend.pkg.recipe
@@ -1,32 +1,30 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
+<dict>
+	<key>Comment</key>
+	<string>Created with Recipe Robot v1.0.5 (https://github.com/homebysix/recipe-robot)</string>
+	<key>Description</key>
+	<string>Downloads the latest version of HexFiend and creates a package.</string>
+	<key>Identifier</key>
+	<string>com.github.fishd72.pkg.HexFiend</string>
+	<key>Input</key>
 	<dict>
-		<key>Comment</key>
-		<string>Created with Recipe Robot v1.0.5 (https://github.com/homebysix/recipe-robot)</string>
-		<key>Description</key>
-		<string>Downloads the latest version of HexFiend and creates a package.</string>
-		<key>Identifier</key>
-		<string>com.github.fishd72.pkg.HexFiend</string>
-		<key>Input</key>
-		<dict>
-			<key>APP_FILENAME</key>
-			<string>Hex Fiend</string>
-			<key>BUNDLE_ID</key>
-			<string>com.ridiculousfish.HexFiend</string>
-			<key>NAME</key>
-			<string>Hex Fiend</string>
-		</dict>
-		<key>MinimumVersion</key>
-		<string>1.0.0</string>
-		<key>ParentRecipe</key>
-		<string>com.github.michalmmac.download.HexFiend</string>
-		<key>Process</key>
-		<array>
-			<dict>
-				<key>Processor</key>
-				<string>AppPkgCreator</string>
-			</dict>
-		</array>
+		<key>APP_FILENAME</key>
+		<string>Hex Fiend</string>
+		<key>NAME</key>
+		<string>Hex Fiend</string>
 	</dict>
+	<key>MinimumVersion</key>
+	<string>1.0.0</string>
+	<key>ParentRecipe</key>
+	<string>com.github.michalmmac.download.HexFiend</string>
+	<key>Process</key>
+	<array>
+		<dict>
+			<key>Processor</key>
+			<string>AppPkgCreator</string>
+		</dict>
+	</array>
+</dict>
 </plist>

--- a/IDEA-IU/IDEA-IU.pkg.recipe
+++ b/IDEA-IU/IDEA-IU.pkg.recipe
@@ -1,30 +1,28 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
+<dict>
+	<key>Description</key>
+	<string>Downloads the latest version of IntelliJ IDEA and creates a package.</string>
+	<key>Identifier</key>
+	<string>com.github.fishd72.pkg.IDEA-IU</string>
+	<key>Input</key>
 	<dict>
-		<key>Description</key>
-		<string>Downloads the latest version of IntelliJ IDEA and creates a package.</string>
-		<key>Identifier</key>
-		<string>com.github.fishd72.pkg.IDEA-IU</string>
-		<key>Input</key>
-		<dict>
-			<key>APP_FILENAME</key>
-			<string>IntelliJ IDEA</string>
-			<key>BUNDLE_ID</key>
-			<string>com.jetbrains.intellij</string>
-			<key>NAME</key>
-			<string>IDEA-IU</string>
-		</dict>
-		<key>MinimumVersion</key>
-		<string>1.0.0</string>
-		<key>ParentRecipe</key>
-		<string>com.github.mosen.download.IDEA-IU</string>
-		<key>Process</key>
-		<array>
-			<dict>
-				<key>Processor</key>
-				<string>AppPkgCreator</string>
-			</dict>
-		</array>
+		<key>APP_FILENAME</key>
+		<string>IntelliJ IDEA</string>
+		<key>NAME</key>
+		<string>IDEA-IU</string>
 	</dict>
+	<key>MinimumVersion</key>
+	<string>1.0.0</string>
+	<key>ParentRecipe</key>
+	<string>com.github.mosen.download.IDEA-IU</string>
+	<key>Process</key>
+	<array>
+		<dict>
+			<key>Processor</key>
+			<string>AppPkgCreator</string>
+		</dict>
+	</array>
+</dict>
 </plist>

--- a/Keka/Keka.pkg.recipe
+++ b/Keka/Keka.pkg.recipe
@@ -1,32 +1,30 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
+<dict>
+	<key>Comment</key>
+	<string>Created with Recipe Robot v1.0.5 (https://github.com/homebysix/recipe-robot)</string>
+	<key>Description</key>
+	<string>Downloads the latest version of Keka and creates a package.</string>
+	<key>Identifier</key>
+	<string>com.github.fishd72.pkg.Keka</string>
+	<key>Input</key>
 	<dict>
-		<key>Comment</key>
-		<string>Created with Recipe Robot v1.0.5 (https://github.com/homebysix/recipe-robot)</string>
-		<key>Description</key>
-		<string>Downloads the latest version of Keka and creates a package.</string>
-		<key>Identifier</key>
-		<string>com.github.fishd72.pkg.Keka</string>
-		<key>Input</key>
-		<dict>
-			<key>APP_FILENAME</key>
-			<string>Keka</string>
-			<key>BUNDLE_ID</key>
-			<string>com.aone.keka</string>
-			<key>NAME</key>
-			<string>Keka</string>
-		</dict>
-		<key>MinimumVersion</key>
-		<string>1.0.0</string>
-		<key>ParentRecipe</key>
-		<string>com.github.hansen-m.download.Keka</string>
-		<key>Process</key>
-		<array>
-			<dict>
-				<key>Processor</key>
-				<string>AppPkgCreator</string>
-			</dict>
-		</array>
+		<key>APP_FILENAME</key>
+		<string>Keka</string>
+		<key>NAME</key>
+		<string>Keka</string>
 	</dict>
+	<key>MinimumVersion</key>
+	<string>1.0.0</string>
+	<key>ParentRecipe</key>
+	<string>com.github.hansen-m.download.Keka</string>
+	<key>Process</key>
+	<array>
+		<dict>
+			<key>Processor</key>
+			<string>AppPkgCreator</string>
+		</dict>
+	</array>
+</dict>
 </plist>

--- a/MongoDBCompassCommunity/MongoDBCompassCommunity.pkg.recipe
+++ b/MongoDBCompassCommunity/MongoDBCompassCommunity.pkg.recipe
@@ -10,8 +10,6 @@
 	<string>com.github.fishd72.pkg.MongoDBCompassCommunity</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>com.mongodb.compass-community</string>
 		<key>NAME</key>
 		<string>MongoDB Compass Community</string>
 	</dict>

--- a/RoboMongo/RoboMongo.pkg.recipe
+++ b/RoboMongo/RoboMongo.pkg.recipe
@@ -1,41 +1,39 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
+<dict>
+	<key>Description</key>
+	<string>Downloads the latest version of RoboMongo (Robo3T) and creates a package.</string>
+	<key>Identifier</key>
+	<string>com.github.fishd72.pkg.RoboMongo</string>
+	<key>Input</key>
 	<dict>
-		<key>Description</key>
-		<string>Downloads the latest version of RoboMongo (Robo3T) and creates a package.</string>
-		<key>Identifier</key>
-		<string>com.github.fishd72.pkg.RoboMongo</string>
-		<key>Input</key>
-		<dict>
-			<key>APP_FILENAME</key>
-			<string>Robo 3T</string>
-			<key>BUNDLE_ID</key>
-			<string>com.3tsoftwarelabs.robo3t</string>
-			<key>NAME</key>
-			<string>RoboMongo</string>
-		</dict>
-		<key>MinimumVersion</key>
-		<string>1.0.0</string>
-		<key>ParentRecipe</key>
-		<string>com.github.valdore86.download.RoboMongo</string>
-		<key>Process</key>
-		<array>
-			<dict>
-				<key>Arguments</key>
-				<dict>
-					<key>input_plist_path</key>
-					<string>%pathname%/Robo 3T.app/Contents/Info.plist</string>
-					<key>plist_version_key</key>
-					<string>CFBundleVersion</string>
-				</dict>
-				<key>Processor</key>
-				<string>Versioner</string>
-			</dict>
-			<dict>
-				<key>Processor</key>
-				<string>AppPkgCreator</string>
-			</dict>
-		</array>
+		<key>APP_FILENAME</key>
+		<string>Robo 3T</string>
+		<key>NAME</key>
+		<string>RoboMongo</string>
 	</dict>
+	<key>MinimumVersion</key>
+	<string>1.0.0</string>
+	<key>ParentRecipe</key>
+	<string>com.github.valdore86.download.RoboMongo</string>
+	<key>Process</key>
+	<array>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>input_plist_path</key>
+				<string>%pathname%/Robo 3T.app/Contents/Info.plist</string>
+				<key>plist_version_key</key>
+				<string>CFBundleVersion</string>
+			</dict>
+			<key>Processor</key>
+			<string>Versioner</string>
+		</dict>
+		<dict>
+			<key>Processor</key>
+			<string>AppPkgCreator</string>
+		</dict>
+	</array>
+</dict>
 </plist>

--- a/SafariTechPreview/SafariTechnologyPreviewHS.pkg.recipe
+++ b/SafariTechPreview/SafariTechnologyPreviewHS.pkg.recipe
@@ -1,41 +1,39 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
+<dict>
+	<key>Comment</key>
+	<string>Created with Recipe Robot v1.0.5 (https://github.com/homebysix/recipe-robot)</string>
+	<key>Description</key>
+	<string>Downloads the latest version of Safari Technology Preview for High Sierra and extracts the package.</string>
+	<key>Identifier</key>
+	<string>com.github.fishd72.pkg.SafariTechnologyPreviewHS</string>
+	<key>Input</key>
 	<dict>
-		<key>Comment</key>
-		<string>Created with Recipe Robot v1.0.5 (https://github.com/homebysix/recipe-robot)</string>
-		<key>Description</key>
-		<string>Downloads the latest version of Safari Technology Preview for High Sierra and extracts the package.</string>
-		<key>Identifier</key>
-		<string>com.github.fishd72.pkg.SafariTechnologyPreviewHS</string>
-		<key>Input</key>
-		<dict>
-			<key>APP_FILENAME</key>
-			<string>Safari Technology Preview</string>
-			<key>BUNDLE_ID</key>
-			<string>com.apple.SafariTechnologyPreview</string>
-			<key>NAME</key>
-			<string>SafariTechnologyPreview</string>
-			<key>DOWNLOAD_URL</key>
-			<string>https://secure-appldnld.apple.com/STP/041-22612-20181114-184D1786-AA54-11E8-82D8-98865F2D1BD8/SafariTechnologyPreview.dmg</string>
-		</dict>
-		<key>MinimumVersion</key>
-		<string>1.0.0</string>
-		<key>ParentRecipe</key>
-		<string>com.github.jaharmi.download.SafariTechnologyPreview</string>
-		<key>Process</key>
-		<array>
-			<dict>
-			  <key>Arguments</key>
-			  <dict>
-				  <key>source_pkg</key>
-				  <string>%input_path%</string>
-					<key>pkg_path</key>
-					<string>%RECIPE_CACHE_DIR%/%NAME%-HS.pkg</string>
-			  </dict>
-				<key>Processor</key>
-				<string>PkgCopier</string>
-			</dict>
-		</array>
+		<key>APP_FILENAME</key>
+		<string>Safari Technology Preview</string>
+		<key>DOWNLOAD_URL</key>
+		<string>https://secure-appldnld.apple.com/STP/041-22612-20181114-184D1786-AA54-11E8-82D8-98865F2D1BD8/SafariTechnologyPreview.dmg</string>
+		<key>NAME</key>
+		<string>SafariTechnologyPreview</string>
 	</dict>
+	<key>MinimumVersion</key>
+	<string>1.0.0</string>
+	<key>ParentRecipe</key>
+	<string>com.github.jaharmi.download.SafariTechnologyPreview</string>
+	<key>Process</key>
+	<array>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>pkg_path</key>
+				<string>%RECIPE_CACHE_DIR%/%NAME%-HS.pkg</string>
+				<key>source_pkg</key>
+				<string>%input_path%</string>
+			</dict>
+			<key>Processor</key>
+			<string>PkgCopier</string>
+		</dict>
+	</array>
+</dict>
 </plist>

--- a/VisualVM/VisualVM.pkg.recipe
+++ b/VisualVM/VisualVM.pkg.recipe
@@ -1,35 +1,33 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
+<dict>
+	<key>Comment</key>
+	<string>Created with Recipe Robot v1.0.5 (https://github.com/homebysix/recipe-robot)</string>
+	<key>Description</key>
+	<string>Downloads the latest version of VisualVM and creates a package.</string>
+	<key>Identifier</key>
+	<string>com.github.fishd72.pkg.VisualVM</string>
+	<key>Input</key>
 	<dict>
-		<key>Comment</key>
-		<string>Created with Recipe Robot v1.0.5 (https://github.com/homebysix/recipe-robot)</string>
-		<key>Description</key>
-		<string>Downloads the latest version of VisualVM and creates a package.</string>
-		<key>Identifier</key>
-		<string>com.github.fishd72.pkg.VisualVM</string>
-		<key>Input</key>
-		<dict>
-			<key>BUNDLE_ID</key>
-			<string>com.apple.sh</string>
-			<key>NAME</key>
-			<string>VisualVM</string>
-		</dict>
-		<key>MinimumVersion</key>
-		<string>1.0.0</string>
-		<key>ParentRecipe</key>
-		<string>com.github.fishd72.download.VisualVM</string>
-		<key>Process</key>
-		<array>
-			<dict>
-				<key>Arguments</key>
-				<dict>
-					<key>bundleid</key>
-					<string>com.apple.sh</string>
-				</dict>
-				<key>Processor</key>
-				<string>AppPkgCreator</string>
-			</dict>
-		</array>
+		<key>NAME</key>
+		<string>VisualVM</string>
 	</dict>
+	<key>MinimumVersion</key>
+	<string>1.0.0</string>
+	<key>ParentRecipe</key>
+	<string>com.github.fishd72.download.VisualVM</string>
+	<key>Process</key>
+	<array>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>bundleid</key>
+				<string>com.apple.sh</string>
+			</dict>
+			<key>Processor</key>
+			<string>AppPkgCreator</string>
+		</dict>
+	</array>
+</dict>
 </plist>

--- a/pgAdmin4/pgAdmin4.pkg.recipe
+++ b/pgAdmin4/pgAdmin4.pkg.recipe
@@ -1,32 +1,30 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
+<dict>
+	<key>Comment</key>
+	<string>Created with Recipe Robot v1.0.5 (https://github.com/homebysix/recipe-robot)</string>
+	<key>Description</key>
+	<string>Downloads the latest version of pgAdmin4 and creates a package.</string>
+	<key>Identifier</key>
+	<string>com.github.fishd72.pkg.pgAdmin4</string>
+	<key>Input</key>
 	<dict>
-		<key>Comment</key>
-		<string>Created with Recipe Robot v1.0.5 (https://github.com/homebysix/recipe-robot)</string>
-		<key>Description</key>
-		<string>Downloads the latest version of pgAdmin4 and creates a package.</string>
-		<key>Identifier</key>
-		<string>com.github.fishd72.pkg.pgAdmin4</string>
-		<key>Input</key>
-		<dict>
-			<key>APP_FILENAME</key>
-			<string>pgAdmin 4</string>
-			<key>BUNDLE_ID</key>
-			<string>org.pgadmin.pgAdmin4</string>
-			<key>NAME</key>
-			<string>pgAdmin 4</string>
-		</dict>
-		<key>MinimumVersion</key>
-		<string>1.0.0</string>
-		<key>ParentRecipe</key>
-		<string>com.github.bnpl.autopkg.download.pgadmin4</string>
-		<key>Process</key>
-		<array>
-			<dict>
-				<key>Processor</key>
-				<string>AppPkgCreator</string>
-			</dict>
-		</array>
+		<key>APP_FILENAME</key>
+		<string>pgAdmin 4</string>
+		<key>NAME</key>
+		<string>pgAdmin 4</string>
 	</dict>
+	<key>MinimumVersion</key>
+	<string>1.0.0</string>
+	<key>ParentRecipe</key>
+	<string>com.github.bnpl.autopkg.download.pgadmin4</string>
+	<key>Process</key>
+	<array>
+		<dict>
+			<key>Processor</key>
+			<string>AppPkgCreator</string>
+		</dict>
+	</array>
+</dict>
 </plist>


### PR DESCRIPTION
This pull request removes unused instances of `BUNDLE_ID` from recipe input variables, which will help reduce confusion by new AutoPkg users and simplify overrides created from this point on.

Making `BUNDLE_ID` available as an input variable is a common practice in AutoPkg recipes that use the [PkgCreator](https://github.com/autopkg/autopkg/wiki/Processor-PkgCreator) processor ([example](https://github.com/autopkg/homebysix-recipes/blob/4fec9244a3af0f9b7c8f61f35a5cd7f4622fb162/soma-zone/LaunchControl.pkg.recipe#L40-L41)). It's likely that these recipes transitioned from PkgCreator to the more streamlined [AppPkgCreator](https://github.com/autopkg/autopkg/wiki/Processor-AppPkgCreator) processor some time ago, but the now-unused input variable for `BUNDLE_ID` was never removed.

Because an automated script helped make this change, modified recipes have also been converted to align with the output of `plutil -convert xml` and Python's `plistlib`. This results in reordering of dictionary keys and reindentation using tabs, neither of which will affect the recipe's function.

Recipe run output is included below for all changed recipes (excluding jss and install recipe types). Any run failures are very likely to be unrelated to this change.

## ✅ Brave/Brave.pkg.recipe

```
% /usr/local/bin/autopkg run -vvq repos/fishd72-recipes/Brave/Brave.pkg.recipe
Processing repos/fishd72-recipes/Brave/Brave.pkg.recipe...
SparkleUpdateInfoProvider
{'Input': {'appcast_url': 'https://updates.bravesoftware.com/sparkle/Brave-Browser/stable/appcast.xml'}}
SparkleUpdateInfoProvider: Version retrieved from appcast: 120.103
SparkleUpdateInfoProvider: User-facing version retrieved from appcast: 88.1.20.103
SparkleUpdateInfoProvider: Found URL https://updates-cdn.bravesoftware.com/sparkle/Brave-Browser/stable/120.103/Brave-Browser-x64.dmg
{'Output': {'url': 'https://updates-cdn.bravesoftware.com/sparkle/Brave-Browser/stable/120.103/Brave-Browser-x64.dmg',
            'version': '88.1.20.103'}}
URLDownloader
{'Input': {'filename': 'Brave.dmg',
           'url': 'https://updates-cdn.bravesoftware.com/sparkle/Brave-Browser/stable/120.103/Brave-Browser-x64.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.fishd72.pkg.brave/downloads/Brave.dmg
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.fishd72.pkg.brave/downloads/Brave.dmg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.fishd72.pkg.brave/downloads/Brave.dmg/Brave '
                         'Browser.app',
           'requirement': 'identifier "com.brave.Browser" and anchor apple '
                          'generic and certificate '
                          '1[field.1.2.840.113635.100.6.2.6] /* exists */ and '
                          'certificate leaf[field.1.2.840.113635.100.6.1.13] '
                          '/* exists */ and certificate leaf[subject.OU] = '
                          'KL8N8XSYF4'}}
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.fishd72.pkg.brave/downloads/Brave.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.a6uVWX/Brave Browser.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.a6uVWX/Brave Browser.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.a6uVWX/Brave Browser.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
AppPkgCreator
{'Input': {'version': '88.1.20.103'}}
AppPkgCreator: Mounted disk image ~/Library/AutoPkg/Cache/com.github.fishd72.pkg.brave/downloads/Brave.dmg
AppPkgCreator: Using path '/private/tmp/dmg.R2uE1l/Brave Browser.app' matched from globbed '/private/tmp/dmg.R2uE1l/*.app'.
AppPkgCreator: BundleID: com.brave.Browser
AppPkgCreator: Package already exists at path ~/Library/AutoPkg/Cache/com.github.fishd72.pkg.brave/Brave Browser-88.1.20.103.pkg.
AppPkgCreator: Existing package matches version and identifier, not building.
{'Output': {'version': '88.1.20.103'}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.fishd72.pkg.brave/receipts/Brave.pkg-receipt-20210213-231428.plist

Nothing downloaded, packaged or imported.
```

## ✅ Curse, Inc./Twitch.pkg.recipe

```
% /usr/local/bin/autopkg run -vvq repos/fishd72-recipes/Curse,\ Inc./Twitch.pkg.recipe
Processing repos/fishd72-recipes/Curse, Inc./Twitch.pkg.recipe...
URLDownloader
{'Input': {'filename': 'Twitch.dmg',
           'url': 'https://desktop.twitchsvc.net/installer/mac/Twitch.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.fishd72.pkg.Twitch/downloads/Twitch.dmg
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.fishd72.pkg.Twitch/downloads/Twitch.dmg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.fishd72.pkg.Twitch/downloads/Twitch.dmg/Twitch.app',
           'requirement': 'identifier "com.twitch.desktop" and anchor apple '
                          'generic and certificate '
                          '1[field.1.2.840.113635.100.6.2.6] /* exists */ and '
                          'certificate leaf[field.1.2.840.113635.100.6.1.13] '
                          '/* exists */ and certificate leaf[subject.OU] = '
                          'K6AZ33YM5B'}}
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.fishd72.pkg.Twitch/downloads/Twitch.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.7tcUAx/Twitch.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.7tcUAx/Twitch.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.7tcUAx/Twitch.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
Versioner
{'Input': {'input_plist_path': '~/Library/AutoPkg/Cache/com.github.fishd72.pkg.Twitch/downloads/Twitch.dmg/Twitch.app/Contents/Info.plist',
           'plist_version_key': 'CFBundleShortVersionString'}}
Versioner: Mounted disk image ~/Library/AutoPkg/Cache/com.github.fishd72.pkg.Twitch/downloads/Twitch.dmg
Versioner: Found version 8.59.0 in file /private/tmp/dmg.HOGKLA/Twitch.app/Contents/Info.plist
{'Output': {'version': '8.59.0'}}
AppPkgCreator
{'Input': {'version': '8.59.0'}}
AppPkgCreator: Mounted disk image ~/Library/AutoPkg/Cache/com.github.fishd72.pkg.Twitch/downloads/Twitch.dmg
AppPkgCreator: Using path '/private/tmp/dmg.kJDenY/Twitch.app' matched from globbed '/private/tmp/dmg.kJDenY/*.app'.
AppPkgCreator: BundleID: com.twitch.desktop
AppPkgCreator: Copied /private/tmp/dmg.kJDenY/Twitch.app to ~/Library/AutoPkg/Cache/com.github.fishd72.pkg.Twitch/payload/Applications/Twitch.app
AppPkgCreator: Connecting
AppPkgCreator: Sending packaging request
AppPkgCreator: Disconnecting
AppPkgCreator: Failed to close socket: [Errno 9] Bad file descriptor
{'Output': {'app_pkg_creator_summary_result': {'data': {'identifier': 'com.twitch.desktop',
                                                        'pkg_path': '~/Library/AutoPkg/Cache/com.github.fishd72.pkg.Twitch/Twitch-8.59.0.pkg',
                                                        'version': '8.59.0'},
                                               'report_fields': ['identifier',
                                                                 'version',
                                                                 'pkg_path'],
                                               'summary_text': 'The following '
                                                               'packages were '
                                                               'built:'},
            'new_package_request': True,
            'version': '8.59.0'}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.fishd72.pkg.Twitch/receipts/Twitch.pkg-receipt-20210213-231501.plist

The following packages were built:
    Identifier          Version  Pkg Path                                                                              
    ----------          -------  --------                                                                              
    com.twitch.desktop  8.59.0   ~/Library/AutoPkg/Cache/com.github.fishd72.pkg.Twitch/Twitch-8.59.0.pkg  
```

## ✅ DockerEdge/DockerEdge.pkg.recipe

```
% /usr/local/bin/autopkg run -vvq repos/fishd72-recipes/DockerEdge/DockerEdge.pkg.recipe
Processing repos/fishd72-recipes/DockerEdge/DockerEdge.pkg.recipe...
URLDownloader
{'Input': {'filename': 'Docker.dmg',
           'url': 'https://download.docker.com/mac/edge/Docker.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.fishd72.pkg.DockerEdge/downloads/Docker.dmg
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.fishd72.pkg.DockerEdge/downloads/Docker.dmg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.fishd72.pkg.DockerEdge/downloads/Docker.dmg/Docker.app',
           'requirement': 'anchor apple generic and identifier '
                          '"com.docker.docker" and (certificate '
                          'leaf[field.1.2.840.113635.100.6.1.9] /* exists */ '
                          'or certificate 1[field.1.2.840.113635.100.6.2.6] /* '
                          'exists */ and certificate '
                          'leaf[field.1.2.840.113635.100.6.1.13] /*\n'
                          '\t\t\t\t\t\texists */ and certificate '
                          'leaf[subject.OU] = "9BNSXJN65R")'}}
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.fishd72.pkg.DockerEdge/downloads/Docker.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.YrFd8d/Docker.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.YrFd8d/Docker.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.YrFd8d/Docker.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
Versioner
{'Input': {'input_plist_path': '~/Library/AutoPkg/Cache/com.github.fishd72.pkg.DockerEdge/downloads/Docker.dmg/Docker.app/Contents/Info.plist',
           'plist_version_key': 'CFBundleVersion'}}
Versioner: Mounted disk image ~/Library/AutoPkg/Cache/com.github.fishd72.pkg.DockerEdge/downloads/Docker.dmg
Versioner: Found version 50684 in file /private/tmp/dmg.DMRKO2/Docker.app/Contents/Info.plist
{'Output': {'version': '50684'}}
AppPkgCreator
{'Input': {'pkg_path': '~/Library/AutoPkg/Cache/com.github.fishd72.pkg.DockerEdge/Docker-Edge-50684.pkg',
           'version': '50684'}}
AppPkgCreator: Mounted disk image ~/Library/AutoPkg/Cache/com.github.fishd72.pkg.DockerEdge/downloads/Docker.dmg
AppPkgCreator: Using path '/private/tmp/dmg.0ennb0/Docker.app' matched from globbed '/private/tmp/dmg.0ennb0/*.app'.
AppPkgCreator: BundleID: com.docker.docker
AppPkgCreator: Copied /private/tmp/dmg.0ennb0/Docker.app to ~/Library/AutoPkg/Cache/com.github.fishd72.pkg.DockerEdge/payload/Applications/Docker.app
AppPkgCreator: Connecting
AppPkgCreator: Sending packaging request
AppPkgCreator: Disconnecting
AppPkgCreator: Failed to close socket: [Errno 9] Bad file descriptor
{'Output': {'app_pkg_creator_summary_result': {'data': {'identifier': 'com.docker.docker',
                                                        'pkg_path': '~/Library/AutoPkg/Cache/com.github.fishd72.pkg.DockerEdge/Docker-Edge-50684.pkg',
                                                        'version': '50684'},
                                               'report_fields': ['identifier',
                                                                 'version',
                                                                 'pkg_path'],
                                               'summary_text': 'The following '
                                                               'packages were '
                                                               'built:'},
            'new_package_request': True,
            'version': '50684'}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.fishd72.pkg.DockerEdge/receipts/DockerEdge.pkg-receipt-20210213-232004.plist

The following packages were built:
    Identifier         Version  Pkg Path                                                                                      
    ----------         -------  --------                                                                                      
    com.docker.docker  50684    ~/Library/AutoPkg/Cache/com.github.fishd72.pkg.DockerEdge/Docker-Edge-50684.pkg  
```

## ✅ DrawIO/DrawIO.pkg.recipe

```
% /usr/local/bin/autopkg run -vvq repos/fishd72-recipes/DrawIO/DrawIO.pkg.recipe
Processing repos/fishd72-recipes/DrawIO/DrawIO.pkg.recipe...
GitHubReleasesInfoProvider
{'Input': {'asset_regex': '.*\\.dmg$', 'github_repo': 'jgraph/drawio-desktop'}}
GitHubReleasesInfoProvider: No value supplied for CURL_PATH, setting default value of: /usr/bin/curl
GitHubReleasesInfoProvider: Matched regex '.*\.dmg$' among asset(s): draw.io-14.1.8-windows-installer.exe, draw.io-14.1.8-windows-no-installer.exe, draw.io-14.1.8.dmg, draw.io-14.1.8.dmg.blockmap, draw.io-14.1.8.exe, draw.io-14.1.8.exe.blockmap, draw.io-14.1.8.zip, draw.io-amd64-14.1.8.deb, draw.io-arm64-14.1.8.dmg, draw.io-arm64-14.1.8.dmg.blockmap, draw.io-arm64-14.1.8.zip, draw.io-ia32-14.1.8-windows-32bit-installer.exe, draw.io-ia32-14.1.8-windows-32bit-no-installer.exe, draw.io-ia32-14.1.8.exe, draw.io-ia32-14.1.8.exe.blockmap, draw.io-x86_64-14.1.8.AppImage, draw.io-x86_64-14.1.8.rpm, latest-linux.yml, latest-mac.yml, latest.yml
GitHubReleasesInfoProvider: Selected asset 'draw.io-14.1.8.dmg' from release '14.1.8'
{'Output': {'release_notes': '## Releases Notes for 14.1.8\r\n'
                             '[Windows '
                             'Installer](https://github.com/jgraph/drawio-desktop/releases/download/v14.1.8/draw.io-14.1.8-windows-installer.exe)\r\n'
                             '[Windows No '
                             'Installer](https://github.com/jgraph/drawio-desktop/releases/download/v14.1.8/draw.io-14.1.8-windows-no-installer.exe)\r\n'
                             '[macOS - '
                             'Intel](https://github.com/jgraph/drawio-desktop/releases/download/v14.1.8/draw.io-14.1.8.dmg)\r\n'
                             '[macOS - '
                             'ARM](https://github.com/jgraph/drawio-desktop/releases/download/v14.1.8/draw.io-arm64-14.1.8.dmg)\r\n'
                             'Linux - '
                             '[deb](https://github.com/jgraph/drawio-desktop/releases/download/v14.1.8/draw.io-amd64-14.1.8.deb), '
                             '[snap](https://snapcraft.io/drawio), '
                             '[AppImage](https://github.com/jgraph/drawio-desktop/releases/download/v14.1.8/draw.io-x86_64-14.1.8.AppImage) '
                             'or '
                             '[rpm](https://github.com/jgraph/drawio-desktop/releases/download/v14.1.8/draw.io-x86_64-14.1.8.rpm)\r\n'
                             '[Google Chrome '
                             'OS](https://chrome.google.com/webstore/detail/drawio-desktop/pebppomjfocnoigkeepgbmcifnnlndla/reviews)\r\n'
                             '\r\n'
                             'Windows intel x32 releases are marked -ia32-\r\n'
                             '\r\n'
                             '**ChangeLog:**\r\n'
                             '\r\n'
                             '- Fixes #456 ',
            'url': 'https://github.com/jgraph/drawio-desktop/releases/download/v14.1.8/draw.io-14.1.8.dmg',
            'version': '14.1.8'}}
URLDownloader
{'Input': {'url': 'https://github.com/jgraph/drawio-desktop/releases/download/v14.1.8/draw.io-14.1.8.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.fishd72.pkg.DrawIO/downloads/draw.io-14.1.8.dmg
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.fishd72.pkg.DrawIO/downloads/draw.io-14.1.8.dmg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.fishd72.pkg.DrawIO/downloads/draw.io-14.1.8.dmg/draw.io.app',
           'requirement': 'identifier "com.jgraph.drawio.desktop" and anchor '
                          'apple generic and certificate '
                          '1[field.1.2.840.113635.100.6.2.6] /* exists */ and '
                          'certificate leaf[field.1.2.840.113635.100.6.1.13] '
                          '/* exists */ and certificate leaf[subject.OU] = '
                          'UZEUFB4N53'}}
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.fishd72.pkg.DrawIO/downloads/draw.io-14.1.8.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.SMYmAm/draw.io.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.SMYmAm/draw.io.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.SMYmAm/draw.io.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
AppPkgCreator
{'Input': {'version': '14.1.8'}}
AppPkgCreator: Mounted disk image ~/Library/AutoPkg/Cache/com.github.fishd72.pkg.DrawIO/downloads/draw.io-14.1.8.dmg
AppPkgCreator: Using path '/private/tmp/dmg.AC1Vpe/draw.io.app' matched from globbed '/private/tmp/dmg.AC1Vpe/*.app'.
AppPkgCreator: BundleID: com.jgraph.drawio.desktop
AppPkgCreator: Package already exists at path ~/Library/AutoPkg/Cache/com.github.fishd72.pkg.DrawIO/draw.io-14.1.8.pkg.
AppPkgCreator: Existing package matches version and identifier, not building.
{'Output': {'version': '14.1.8'}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.fishd72.pkg.DrawIO/receipts/DrawIO.pkg-receipt-20210213-232012.plist

Nothing downloaded, packaged or imported.
```

## ✅ Emacs/EmacsForOSX.pkg.recipe

```
% /usr/local/bin/autopkg run -vvq repos/fishd72-recipes/Emacs/EmacsForOSX.pkg.recipe
Processing repos/fishd72-recipes/Emacs/EmacsForOSX.pkg.recipe...
EmacsURLProvider
{'Input': {}}
EmacsURLProvider: Found URL as https://emacsformacosx.com/emacs-builds/Emacs-27.1-1-universal.dmg
{'Output': {'url': 'https://emacsformacosx.com/emacs-builds/Emacs-27.1-1-universal.dmg'}}
URLDownloader
{'Input': {'filename': 'Emacs.dmg',
           'url': 'https://emacsformacosx.com/emacs-builds/Emacs-27.1-1-universal.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.fishd72.pkg.EmacsForOSX/downloads/Emacs.dmg
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.fishd72.pkg.EmacsForOSX/downloads/Emacs.dmg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.fishd72.pkg.EmacsForOSX/downloads/Emacs.dmg/Emacs.app',
           'requirement': 'identifier "org.gnu.Emacs" and anchor apple generic '
                          'and certificate 1[field.1.2.840.113635.100.6.2.6] '
                          '/* exists */ and certificate '
                          'leaf[field.1.2.840.113635.100.6.1.13] /* exists */ '
                          'and certificate leaf[subject.OU] = "5BRAQAFB8B"',
           'strict_verification': True}}
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.fishd72.pkg.EmacsForOSX/downloads/Emacs.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification enabled...
CodeSignatureVerifier: /private/tmp/dmg.jMKEqQ/Emacs.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.jMKEqQ/Emacs.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.jMKEqQ/Emacs.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
AppPkgCreator
{'Input': {}}
AppPkgCreator: Mounted disk image ~/Library/AutoPkg/Cache/com.github.fishd72.pkg.EmacsForOSX/downloads/Emacs.dmg
AppPkgCreator: Using path '/private/tmp/dmg.lAhVhf/Emacs.app' matched from globbed '/private/tmp/dmg.lAhVhf/*.app'.
AppPkgCreator: Version: 27.1
AppPkgCreator: BundleID: org.gnu.Emacs
AppPkgCreator: Copied /private/tmp/dmg.lAhVhf/Emacs.app to ~/Library/AutoPkg/Cache/com.github.fishd72.pkg.EmacsForOSX/payload/Applications/Emacs.app
AppPkgCreator: Connecting
AppPkgCreator: Sending packaging request
AppPkgCreator: Disconnecting
AppPkgCreator: Failed to close socket: [Errno 9] Bad file descriptor
{'Output': {'app_pkg_creator_summary_result': {'data': {'identifier': 'org.gnu.Emacs',
                                                        'pkg_path': '~/Library/AutoPkg/Cache/com.github.fishd72.pkg.EmacsForOSX/Emacs-27.1.pkg',
                                                        'version': '27.1'},
                                               'report_fields': ['identifier',
                                                                 'version',
                                                                 'pkg_path'],
                                               'summary_text': 'The following '
                                                               'packages were '
                                                               'built:'},
            'new_package_request': True,
            'version': '27.1'}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.fishd72.pkg.EmacsForOSX/receipts/EmacsForOSX.pkg-receipt-20210213-232149.plist

The following packages were built:
    Identifier     Version  Pkg Path                                                                                
    ----------     -------  --------                                                                                
    org.gnu.Emacs  27.1     ~/Library/AutoPkg/Cache/com.github.fishd72.pkg.EmacsForOSX/Emacs-27.1.pkg  
```

## ✅ Etcher/Etcher.pkg.recipe

```
% /usr/local/bin/autopkg run -vvq repos/fishd72-recipes/Etcher/Etcher.pkg.recipe
Processing repos/fishd72-recipes/Etcher/Etcher.pkg.recipe...
GitHubReleasesInfoProvider
{'Input': {'asset_regex': 'balenaEtcher-[\\S]+\\.dmg',
           'github_repo': 'balena-io/etcher',
           'include_prereleases': ''}}
GitHubReleasesInfoProvider: No value supplied for CURL_PATH, setting default value of: /usr/bin/curl
GitHubReleasesInfoProvider: Matched regex 'balenaEtcher-[\S]+\.dmg' among asset(s): balena-etcher-electron-1.5.116-linux-ia32.zip, balena-etcher-electron-1.5.116-linux-x64.zip, balena-etcher-electron-1.5.116.i686.rpm, balena-etcher-electron-1.5.116.x86_64.rpm, balena-etcher-electron_1.5.116_amd64.deb, balena-etcher-electron_1.5.116_i386.deb, balenaEtcher-1.5.116-ia32.AppImage, balenaEtcher-1.5.116-mac.zip, balenaEtcher-1.5.116-x64.AppImage, balenaEtcher-1.5.116.dmg, balenaEtcher-1.5.116.dmg.blockmap, balenaEtcher-Portable-1.5.116.exe, balenaEtcher-Setup-1.5.116.exe, balenaEtcher-Setup-1.5.116.exe.blockmap, builder-effective-config.yaml, latest-linux-ia32.yml, latest-linux.yml, latest-mac.yml, latest.yml
GitHubReleasesInfoProvider: Selected asset 'balenaEtcher-1.5.116.dmg' from release 'v1.5.116'
{'Output': {'release_notes': '1.5.116',
            'url': 'https://github.com/balena-io/etcher/releases/download/v1.5.116/balenaEtcher-1.5.116.dmg',
            'version': '1.5.116'}}
URLDownloader
{'Input': {'url': 'https://github.com/balena-io/etcher/releases/download/v1.5.116/balenaEtcher-1.5.116.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.fishd72.pkg.Etcher/downloads/balenaEtcher-1.5.116.dmg
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.fishd72.pkg.Etcher/downloads/balenaEtcher-1.5.116.dmg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.fishd72.pkg.Etcher/downloads/balenaEtcher-1.5.116.dmg/balenaEtcher.app',
           'requirement': 'identifier "io.balena.etcher" and anchor apple '
                          'generic and certificate '
                          '1[field.1.2.840.113635.100.6.2.6] /* exists */ and '
                          'certificate leaf[field.1.2.840.113635.100.6.1.13] '
                          '/* exists */ and certificate leaf[subject.OU] = '
                          '"66H43P8FRG"'}}
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.fishd72.pkg.Etcher/downloads/balenaEtcher-1.5.116.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.wOI78s/balenaEtcher.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.wOI78s/balenaEtcher.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.wOI78s/balenaEtcher.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
AppPkgCreator
{'Input': {'version': '1.5.116'}}
AppPkgCreator: Mounted disk image ~/Library/AutoPkg/Cache/com.github.fishd72.pkg.Etcher/downloads/balenaEtcher-1.5.116.dmg
AppPkgCreator: Using path '/private/tmp/dmg.hiY35T/balenaEtcher.app' matched from globbed '/private/tmp/dmg.hiY35T/*.app'.
AppPkgCreator: BundleID: io.balena.etcher
AppPkgCreator: Package already exists at path ~/Library/AutoPkg/Cache/com.github.fishd72.pkg.Etcher/balenaEtcher-1.5.116.pkg.
AppPkgCreator: Existing package matches version and identifier, not building.
{'Output': {'version': '1.5.116'}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.fishd72.pkg.Etcher/receipts/Etcher.pkg-receipt-20210213-232156.plist

Nothing downloaded, packaged or imported.
```

## ❌ Freeplane/Freeplane.pkg.recipe

```
% /usr/local/bin/autopkg run -vvq repos/fishd72-recipes/Freeplane/Freeplane.pkg.recipe
Processing repos/fishd72-recipes/Freeplane/Freeplane.pkg.recipe...
com.github.jessepeterson.munki.GrandPerspective/SourceForgeURLProvider
{'Input': {'SOURCEFORGE_FILE_PATTERN': 'freeplane_app_jre-[\\d.]*\\.dmg',
           'SOURCEFORGE_PROJECT_ID': 211069}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.fishd72.pkg.Freeplane/receipts/Freeplane.pkg-receipt-20210213-232200.plist

The following recipes failed:
    repos/fishd72-recipes/Freeplane/Freeplane.pkg.recipe
        Error in com.github.fishd72.pkg.Freeplane: Processor: com.github.jessepeterson.munki.GrandPerspective/SourceForgeURLProvider: Error: No matched files

Nothing downloaded, packaged or imported.
```

## ❌ Ghost/Ghost.pkg.recipe

```
% /usr/local/bin/autopkg run -vvq repos/fishd72-recipes/Ghost/Ghost.pkg.recipe
Processing repos/fishd72-recipes/Ghost/Ghost.pkg.recipe...
GitHubReleasesInfoProvider
{'Input': {'asset_regex': 'ghost-desktop-[\\S]+\\.dmg',
           'github_repo': 'TryGhost/Ghost-Desktop'}}
GitHubReleasesInfoProvider: No value supplied for CURL_PATH, setting default value of: /usr/bin/curl
Receipt written to ~/Library/AutoPkg/Cache/com.github.fishd72.pkg.Ghost/receipts/Ghost.pkg-receipt-20210213-232202.plist

The following recipes failed:
    repos/fishd72-recipes/Ghost/Ghost.pkg.recipe
        Error in com.github.fishd72.pkg.Ghost: Processor: GitHubReleasesInfoProvider: Error: Command '['/usr/bin/curl', '--location', '--silent', '--show-error', '--fail', '--dump-header', '-', '-X', 'GET', '--header', 'User-Agent: AutoPkg', '--header', 'Accept: application/vnd.github.v3+json', '--header', 'Authorization: token ef560af5f8d3ace55347c9d01d4d96f1a17d8794', '--url', 'https://api.github.com/repos/TryGhost/Ghost-Desktop/releases', '--output', '/var/folders/jj/4ykdc7714tq8jwb25_j8czxh0000gn/T/tmprgeoqq9q']' returned non-zero exit status 22.

Nothing downloaded, packaged or imported.
```

## ✅ GoogleChromeCanary/GoogleChromeCanary.pkg.recipe

```
% /usr/local/bin/autopkg run -vvq repos/fishd72-recipes/GoogleChromeCanary/GoogleChromeCanary.pkg.recipe
Processing repos/fishd72-recipes/GoogleChromeCanary/GoogleChromeCanary.pkg.recipe...
URLDownloader
{'Input': {'filename': 'Chrome.dmg',
           'url': 'https://dl.google.com/release2/q/canary/googlechrome.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.fishd72.pkg.Chrome/downloads/Chrome.dmg
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.fishd72.pkg.Chrome/downloads/Chrome.dmg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.fishd72.pkg.Chrome/downloads/Chrome.dmg/Google '
                         'Chrome Canary.app',
           'requirement': '(identifier "com.google.Chrome" or identifier '
                          '"com.google.Chrome.beta" or identifier '
                          '"com.google.Chrome.dev" or identifier '
                          '"com.google.Chrome.canary") and certificate leaf = '
                          'H"c9a99324ca3fcb23dbcc36bd5fd4f9753305130a"'}}
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.fishd72.pkg.Chrome/downloads/Chrome.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.4J0BxF/Google Chrome Canary.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.4J0BxF/Google Chrome Canary.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.4J0BxF/Google Chrome Canary.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
AppPkgCreator
{'Input': {}}
AppPkgCreator: Mounted disk image ~/Library/AutoPkg/Cache/com.github.fishd72.pkg.Chrome/downloads/Chrome.dmg
AppPkgCreator: Using path '/private/tmp/dmg.RqVN3E/Google Chrome Canary.app' matched from globbed '/private/tmp/dmg.RqVN3E/*.app'.
AppPkgCreator: Version: 90.0.4417.0
AppPkgCreator: BundleID: com.google.Chrome.canary
AppPkgCreator: Copied /private/tmp/dmg.RqVN3E/Google Chrome Canary.app to ~/Library/AutoPkg/Cache/com.github.fishd72.pkg.Chrome/payload/Applications/Google Chrome Canary.app
AppPkgCreator: Connecting
AppPkgCreator: Sending packaging request
AppPkgCreator: Disconnecting
AppPkgCreator: Failed to close socket: [Errno 9] Bad file descriptor
{'Output': {'app_pkg_creator_summary_result': {'data': {'identifier': 'com.google.Chrome.canary',
                                                        'pkg_path': '~/Library/AutoPkg/Cache/com.github.fishd72.pkg.Chrome/Google '
                                                                    'Chrome '
                                                                    'Canary-90.0.4417.0.pkg',
                                                        'version': '90.0.4417.0'},
                                               'report_fields': ['identifier',
                                                                 'version',
                                                                 'pkg_path'],
                                               'summary_text': 'The following '
                                                               'packages were '
                                                               'built:'},
            'new_package_request': True,
            'version': '90.0.4417.0'}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.fishd72.pkg.Chrome/receipts/GoogleChromeCanary.pkg-receipt-20210213-232312.plist

The following packages were built:
    Identifier                Version      Pkg Path                                                                                                 
    ----------                -------      --------                                                                                                 
    com.google.Chrome.canary  90.0.4417.0  ~/Library/AutoPkg/Cache/com.github.fishd72.pkg.Chrome/Google Chrome Canary-90.0.4417.0.pkg  
```

## ✅ HexFiend/HexFiend.pkg.recipe

```
% /usr/local/bin/autopkg run -vvq repos/fishd72-recipes/HexFiend/HexFiend.pkg.recipe
Processing repos/fishd72-recipes/HexFiend/HexFiend.pkg.recipe...
GitHubReleasesInfoProvider
{'Input': {'github_repo': 'ridiculousfish/HexFiend'}}
GitHubReleasesInfoProvider: No value supplied for CURL_PATH, setting default value of: /usr/bin/curl
GitHubReleasesInfoProvider: Selected asset 'Hex_Fiend_2.14.dmg' from release ''
{'Output': {'release_notes': '[Release '
                             'Notes](https://hexfiend.github.io/HexFiend/ReleaseNotes.html)',
            'url': 'https://github.com/HexFiend/HexFiend/releases/download/v2.14.0/Hex_Fiend_2.14.dmg',
            'version': '2.14.0'}}
URLDownloader
{'Input': {'url': 'https://github.com/HexFiend/HexFiend/releases/download/v2.14.0/Hex_Fiend_2.14.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.fishd72.pkg.HexFiend/downloads/Hex_Fiend_2.14.dmg
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.fishd72.pkg.HexFiend/downloads/Hex_Fiend_2.14.dmg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.fishd72.pkg.HexFiend/downloads/Hex_Fiend_2.14.dmg/Hex '
                         'Fiend.app',
           'requirement': 'anchor apple generic and identifier '
                          '"com.ridiculousfish.HexFiend" and (certificate '
                          'leaf[field.1.2.840.113635.100.6.1.9] /* exists */ '
                          'or certificate 1[field.1.2.840.113635.100.6.2.6] /* '
                          'exists */ and certificate '
                          'leaf[field.1.2.840.113635.100.6.1.13] /* exists */ '
                          'and certificate leaf[subject.OU] = QK92QP33YN)'}}
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.fishd72.pkg.HexFiend/downloads/Hex_Fiend_2.14.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.NEEM6j/Hex Fiend.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.NEEM6j/Hex Fiend.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.NEEM6j/Hex Fiend.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
AppPkgCreator
{'Input': {'version': '2.14.0'}}
AppPkgCreator: Mounted disk image ~/Library/AutoPkg/Cache/com.github.fishd72.pkg.HexFiend/downloads/Hex_Fiend_2.14.dmg
AppPkgCreator: Using path '/private/tmp/dmg.ZBDYLk/Hex Fiend.app' matched from globbed '/private/tmp/dmg.ZBDYLk/*.app'.
AppPkgCreator: BundleID: com.ridiculousfish.HexFiend
AppPkgCreator: Package already exists at path ~/Library/AutoPkg/Cache/com.github.fishd72.pkg.HexFiend/Hex Fiend-2.14.0.pkg.
AppPkgCreator: Existing package matches version and identifier, not building.
{'Output': {'version': '2.14.0'}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.fishd72.pkg.HexFiend/receipts/HexFiend.pkg-receipt-20210213-232318.plist

Nothing downloaded, packaged or imported.
```

## ✅ IDEA-IU/IDEA-IU.pkg.recipe

```
% /usr/local/bin/autopkg run -vvq repos/fishd72-recipes/IDEA-IU/IDEA-IU.pkg.recipe
Processing repos/fishd72-recipes/IDEA-IU/IDEA-IU.pkg.recipe...
JetbrainsURLProvider
{'Input': {'product_code': 'IIU'}}
JetbrainsURLProvider: Found URL https://download.jetbrains.com/idea/ideaIU-2020.3.2.dmg
{'Output': {'build': '203.7148.57',
            'majorVersion': '2020.3',
            'url': 'https://download.jetbrains.com/idea/ideaIU-2020.3.2.dmg',
            'version': '2020.3.2'}}
URLDownloader
{'Input': {'url': 'https://download.jetbrains.com/idea/ideaIU-2020.3.2.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.fishd72.pkg.IDEA-IU/downloads/ideaIU-2020.3.2.dmg
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.fishd72.pkg.IDEA-IU/downloads/ideaIU-2020.3.2.dmg'}}
AppDmgVersioner
{'Input': {'dmg_path': '~/Library/AutoPkg/Cache/com.github.fishd72.pkg.IDEA-IU/downloads/ideaIU-2020.3.2.dmg'}}
AppDmgVersioner: Mounted disk image ~/Library/AutoPkg/Cache/com.github.fishd72.pkg.IDEA-IU/downloads/ideaIU-2020.3.2.dmg
AppDmgVersioner: BundleID: com.jetbrains.intellij
AppDmgVersioner: Version: 2020.3.2
{'Output': {'app_name': 'IntelliJ IDEA.app',
            'bundleid': 'com.jetbrains.intellij',
            'version': '2020.3.2'}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.fishd72.pkg.IDEA-IU/downloads/ideaIU-2020.3.2.dmg/IntelliJ '
                         'IDEA.app',
           'requirement': 'identifier "com.jetbrains.intellij" and anchor '
                          'apple generic and certificate '
                          '1[field.1.2.840.113635.100.6.2.6] /* exists */ and '
                          'certificate leaf[field.1.2.840.113635.100.6.1.13] '
                          '/* exists */ and certificate leaf[subject.OU] = '
                          '"2ZEFAR8TH3"'}}
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.fishd72.pkg.IDEA-IU/downloads/ideaIU-2020.3.2.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.Dk1opC/IntelliJ IDEA.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.Dk1opC/IntelliJ IDEA.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.Dk1opC/IntelliJ IDEA.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
AppPkgCreator
{'Input': {'bundleid': 'com.jetbrains.intellij', 'version': '2020.3.2'}}
AppPkgCreator: Mounted disk image ~/Library/AutoPkg/Cache/com.github.fishd72.pkg.IDEA-IU/downloads/ideaIU-2020.3.2.dmg
AppPkgCreator: Using path '/private/tmp/dmg.jfwmbs/IntelliJ IDEA.app' matched from globbed '/private/tmp/dmg.jfwmbs/*.app'.
AppPkgCreator: Copied /private/tmp/dmg.jfwmbs/IntelliJ IDEA.app to ~/Library/AutoPkg/Cache/com.github.fishd72.pkg.IDEA-IU/payload/Applications/IntelliJ IDEA.app
AppPkgCreator: Connecting
AppPkgCreator: Sending packaging request
AppPkgCreator: Disconnecting
AppPkgCreator: Failed to close socket: [Errno 9] Bad file descriptor
{'Output': {'app_pkg_creator_summary_result': {'data': {'identifier': 'com.jetbrains.intellij',
                                                        'pkg_path': '~/Library/AutoPkg/Cache/com.github.fishd72.pkg.IDEA-IU/IntelliJ '
                                                                    'IDEA-2020.3.2.pkg',
                                                        'version': '2020.3.2'},
                                               'report_fields': ['identifier',
                                                                 'version',
                                                                 'pkg_path'],
                                               'summary_text': 'The following '
                                                               'packages were '
                                                               'built:'},
            'new_package_request': True,
            'version': '2020.3.2'}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.fishd72.pkg.IDEA-IU/receipts/IDEA-IU.pkg-receipt-20210213-232458.plist

The following packages were built:
    Identifier              Version   Pkg Path                                                                                        
    ----------              -------   --------                                                                                        
    com.jetbrains.intellij  2020.3.2  ~/Library/AutoPkg/Cache/com.github.fishd72.pkg.IDEA-IU/IntelliJ IDEA-2020.3.2.pkg  
```

## ✅ Keka/Keka.pkg.recipe

```
% /usr/local/bin/autopkg run -vvq repos/fishd72-recipes/Keka/Keka.pkg.recipe
Processing repos/fishd72-recipes/Keka/Keka.pkg.recipe...
URLDownloader
{'Input': {'filename': 'Keka.dmg', 'url': 'https://d.keka.io/'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.fishd72.pkg.Keka/downloads/Keka.dmg
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.fishd72.pkg.Keka/downloads/Keka.dmg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
AppPkgCreator
{'Input': {}}
AppPkgCreator: Mounted disk image ~/Library/AutoPkg/Cache/com.github.fishd72.pkg.Keka/downloads/Keka.dmg
AppPkgCreator: Using path '/private/tmp/dmg.zM93FA/Keka.app' matched from globbed '/private/tmp/dmg.zM93FA/*.app'.
AppPkgCreator: Version: 1.2.9
AppPkgCreator: BundleID: com.aone.keka
AppPkgCreator: Package already exists at path ~/Library/AutoPkg/Cache/com.github.fishd72.pkg.Keka/Keka-1.2.9.pkg.
AppPkgCreator: Existing package matches version and identifier, not building.
{'Output': {'version': '1.2.9'}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.fishd72.pkg.Keka/receipts/Keka.pkg-receipt-20210213-232501.plist

Nothing downloaded, packaged or imported.
```

## ❌ MongoDBCompassCommunity/MongoDBCompassCommunity.pkg.recipe

```
% /usr/local/bin/autopkg run -vvq repos/fishd72-recipes/MongoDBCompassCommunity/MongoDBCompassCommunity.pkg.recipe
Processing repos/fishd72-recipes/MongoDBCompassCommunity/MongoDBCompassCommunity.pkg.recipe...
URLTextSearcher
{'Input': {'re_pattern': 'https:\\/\\/downloads\\.mongodb\\.com\\/compass\\/mongodb-compass-community-[\\S]+-darwin-x64\\.dmg',
           'url': 'https://www.mongodb.com/download-center/compass'}}
URLTextSearcher: No value supplied for result_output_var_name, setting default value of: match
Receipt written to ~/Library/AutoPkg/Cache/com.github.fishd72.pkg.MongoDBCompassCommunity/receipts/MongoDBCompassCommunity.pkg-receipt-20210213-232504.plist

The following recipes failed:
    repos/fishd72-recipes/MongoDBCompassCommunity/MongoDBCompassCommunity.pkg.recipe
        Error in com.github.fishd72.pkg.MongoDBCompassCommunity: Processor: URLTextSearcher: Error: No match found on URL: https://www.mongodb.com/download-center/compass

Nothing downloaded, packaged or imported.
```

## ✅ RoboMongo/RoboMongo.pkg.recipe

```
% /usr/local/bin/autopkg run -vvq repos/fishd72-recipes/RoboMongo/RoboMongo.pkg.recipe
Processing repos/fishd72-recipes/RoboMongo/RoboMongo.pkg.recipe...
GitHubReleasesInfoProvider
{'Input': {'asset_regex': 'robo3t.*dmg', 'github_repo': 'Studio3T/robomongo'}}
GitHubReleasesInfoProvider: No value supplied for CURL_PATH, setting default value of: /usr/bin/curl
GitHubReleasesInfoProvider: Matched regex 'robo3t.*dmg' among asset(s): robo3t-1.4.3-darwin-x86_64-48f7dfd.dmg, robo3t-1.4.3-linux-x86_64-48f7dfd.tar.gz, robo3t-1.4.3-windows-x86_64-48f7dfde.exe, robo3t-1.4.3-windows-x86_64-48f7dfde.zip
GitHubReleasesInfoProvider: Selected asset 'robo3t-1.4.3-darwin-x86_64-48f7dfd.dmg' from release 'Robo 3T 1.4.3 - Beta'
{'Output': {'release_notes': '  New Features:\r\n'
                             '  - macOS Big Sur support \r\n'
                             '  - New Welcome Tab - embeds Chromium using '
                             'QtWebEngine (Windows, macOS only)\r\n'
                             '  - Database explorer section has smaller '
                             'default width (#1556)\r\n'
                             '  - Remember database explorer section size \r\n'
                             '  - Import keys from old version: autoExpand, '
                             'lineNumbers, debugMode and shellTimeoutSec\r\n'
                             '\r\n'
                             '  Fixes:\r\n'
                             '  - Disable unsupported SSH tab for replica set '
                             'connections #1285 #1340\r\n'
                             '  - Fix a crash when new shell tab executed in '
                             'server unreachable case\r\n'
                             '  - Fix a crash when paging used in tabbed '
                             'result window (#1661)\r\n'
                             '  - Fix broken F2, F3, F4 shortcuts for tabbed '
                             'result view\r\n'
                             '  - One time re-order limit per new connections '
                             'window to prevent data loss (macOS, #1790)\r\n'
                             '  - Fix previously broken IPv6 support from '
                             'command line: `robo3t --ipv6`\r\n',
            'url': 'https://github.com/Studio3T/robomongo/releases/download/v1.4.3-beta/robo3t-1.4.3-darwin-x86_64-48f7dfd.dmg',
            'version': '1.4.3-beta'}}
URLDownloader
{'Input': {'filename': 'RoboMongo.dmg',
           'url': 'https://github.com/Studio3T/robomongo/releases/download/v1.4.3-beta/robo3t-1.4.3-darwin-x86_64-48f7dfd.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.fishd72.pkg.RoboMongo/downloads/RoboMongo.dmg
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.fishd72.pkg.RoboMongo/downloads/RoboMongo.dmg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Versioner
{'Input': {'input_plist_path': '~/Library/AutoPkg/Cache/com.github.fishd72.pkg.RoboMongo/downloads/RoboMongo.dmg/Robo '
                               '3T.app/Contents/Info.plist',
           'plist_version_key': 'CFBundleVersion'}}
Versioner: Mounted disk image ~/Library/AutoPkg/Cache/com.github.fishd72.pkg.RoboMongo/downloads/RoboMongo.dmg
Versioner: Found version 1.4.3 in file /private/tmp/dmg.GXDHAD/Robo 3T.app/Contents/Info.plist
{'Output': {'version': '1.4.3'}}
AppPkgCreator
{'Input': {'version': '1.4.3'}}
AppPkgCreator: Mounted disk image ~/Library/AutoPkg/Cache/com.github.fishd72.pkg.RoboMongo/downloads/RoboMongo.dmg
AppPkgCreator: Using path '/private/tmp/dmg.9ZNqGx/Robo 3T.app' matched from globbed '/private/tmp/dmg.9ZNqGx/*.app'.
AppPkgCreator: BundleID: com.3tsoftwarelabs.robo3t
AppPkgCreator: Package already exists at path ~/Library/AutoPkg/Cache/com.github.fishd72.pkg.RoboMongo/Robo 3T-1.4.3.pkg.
AppPkgCreator: Existing package matches version and identifier, not building.
{'Output': {'version': '1.4.3'}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.fishd72.pkg.RoboMongo/receipts/RoboMongo.pkg-receipt-20210213-232509.plist

Nothing downloaded, packaged or imported.
```

## ❌ SafariTechPreview/SafariTechnologyPreviewHS.pkg.recipe

```
% /usr/local/bin/autopkg run -vvq repos/fishd72-recipes/SafariTechPreview/SafariTechnologyPreviewHS.pkg.recipe
Processing repos/fishd72-recipes/SafariTechPreview/SafariTechnologyPreviewHS.pkg.recipe...
URLDownloader
{'Input': {'url': 'https://secure-appldnld.apple.com/STP/041-22612-20181114-184D1786-AA54-11E8-82D8-98865F2D1BD8/SafariTechnologyPreview.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.fishd72.pkg.SafariTechnologyPreviewHS/downloads/SafariTechnologyPreview.dmg
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.fishd72.pkg.SafariTechnologyPreviewHS/downloads/SafariTechnologyPreview.dmg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'expected_authority_names': ['Software Update',
                                        'Apple Software Update Certification '
                                        'Authority',
                                        'Apple Root CA'],
           'input_path': '~/Library/AutoPkg/Cache/com.github.fishd72.pkg.SafariTechnologyPreviewHS/downloads/SafariTechnologyPreview.dmg/Safari '
                         'Technology Preview*.pkg'}}
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.fishd72.pkg.SafariTechnologyPreviewHS/downloads/SafariTechnologyPreview.dmg
CodeSignatureVerifier: Using path '/private/tmp/dmg.y0w8KG/Safari Technology Preview.pkg' matched from globbed '/private/tmp/dmg.y0w8KG/Safari Technology Preview*.pkg'.
CodeSignatureVerifier: Verifying installer package signature...
CodeSignatureVerifier: Package "Safari Technology Preview.pkg":
CodeSignatureVerifier:    Status: signed by a certificate that has since expired
CodeSignatureVerifier:    Certificate Chain:
CodeSignatureVerifier:     1. Software Update
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            3A 29 97 4F ED 84 A2 36 C5 D2 AA B5 30 91 6D C4 4C A9 6C 1A 03 10 
CodeSignatureVerifier:            17 B8 3E FC 90 0E B4 4E 45 33
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     2. Apple Software Update Certification Authority
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            AE 4B A7 57 65 A2 D9 1A 9F 86 6E E1 2A B1 53 F8 75 9B C1 D1 29 46 
CodeSignatureVerifier:            0E 7D B5 FF 45 FC 98 6F 98 7A
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     3. Apple Root CA
CodeSignatureVerifier:        Expires: 2035-02-09 21:40:36 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            B0 B1 73 0E CB C7 FF 45 05 14 2C 49 F1 29 5E 6E DA 6B CA ED 7E 2C 
CodeSignatureVerifier:            68 C5 BE 91 B5 A1 10 01 F0 24
CodeSignatureVerifier: 
Receipt written to ~/Library/AutoPkg/Cache/com.github.fishd72.pkg.SafariTechnologyPreviewHS/receipts/SafariTechnologyPreviewHS.pkg-receipt-20210213-232512.plist

The following recipes failed:
    repos/fishd72-recipes/SafariTechPreview/SafariTechnologyPreviewHS.pkg.recipe
        Error in com.github.fishd72.pkg.SafariTechnologyPreviewHS: Processor: CodeSignatureVerifier: Error: Code signature verification failed. Note that all verification can be disabled by setting the variable DISABLE_CODE_SIGNATURE_VERIFICATION to a non-empty value.

Nothing downloaded, packaged or imported.
```

## ✅ VisualVM/VisualVM.pkg.recipe

```
% /usr/local/bin/autopkg run -vvq repos/fishd72-recipes/VisualVM/VisualVM.pkg.recipe
Processing repos/fishd72-recipes/VisualVM/VisualVM.pkg.recipe...
GitHubReleasesInfoProvider
{'Input': {'asset_regex': 'VisualVM_[\\S]+\\.dmg',
           'github_repo': 'oracle/visualvm'}}
GitHubReleasesInfoProvider: No value supplied for CURL_PATH, setting default value of: /usr/bin/curl
GitHubReleasesInfoProvider: Matched regex 'VisualVM_[\S]+\.dmg' among asset(s): org-graalvm-visualvm-modules-graaljs.nbm, VisualVM_206.dmg, visualvm_206.zip
GitHubReleasesInfoProvider: Selected asset 'VisualVM_206.dmg' from release 'VisualVM 2.0.6'
{'Output': {'release_notes': '\r\n',
            'url': 'https://github.com/oracle/visualvm/releases/download/2.0.6/VisualVM_206.dmg',
            'version': '2.0.6'}}
URLDownloader
{'Input': {'filename': 'VisualVM-2.0.6.dmg',
           'url': 'https://github.com/oracle/visualvm/releases/download/2.0.6/VisualVM_206.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.fishd72.pkg.VisualVM/downloads/VisualVM-2.0.6.dmg
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.fishd72.pkg.VisualVM/downloads/VisualVM-2.0.6.dmg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.fishd72.pkg.VisualVM/downloads/VisualVM-2.0.6.dmg/VisualVM.app',
           'requirement': 'identifier VisualVM and anchor apple generic and '
                          'certificate 1[field.1.2.840.113635.100.6.2.6] /* '
                          'exists */ and certificate '
                          'leaf[field.1.2.840.113635.100.6.1.13] /* exists */ '
                          'and certificate leaf[subject.OU] = VB5E2TV963'}}
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.fishd72.pkg.VisualVM/downloads/VisualVM-2.0.6.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.onNXWJ/VisualVM.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.onNXWJ/VisualVM.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.onNXWJ/VisualVM.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
Versioner
{'Input': {'input_plist_path': '~/Library/AutoPkg/Cache/com.github.fishd72.pkg.VisualVM/downloads/VisualVM-2.0.6.dmg/VisualVM.app/Contents/Info.plist',
           'plist_version_key': 'CFBundleShortVersionString'}}
Versioner: Mounted disk image ~/Library/AutoPkg/Cache/com.github.fishd72.pkg.VisualVM/downloads/VisualVM-2.0.6.dmg
Versioner: Found version 2.0.6 in file /private/tmp/dmg.pQjOhu/VisualVM.app/Contents/Info.plist
{'Output': {'version': '2.0.6'}}
AppPkgCreator
{'Input': {'bundleid': 'com.apple.sh', 'version': '2.0.6'}}
AppPkgCreator: Mounted disk image ~/Library/AutoPkg/Cache/com.github.fishd72.pkg.VisualVM/downloads/VisualVM-2.0.6.dmg
AppPkgCreator: Using path '/private/tmp/dmg.0Ff8SY/VisualVM.app' matched from globbed '/private/tmp/dmg.0Ff8SY/*.app'.
AppPkgCreator: Copied /private/tmp/dmg.0Ff8SY/VisualVM.app to ~/Library/AutoPkg/Cache/com.github.fishd72.pkg.VisualVM/payload/Applications/VisualVM.app
AppPkgCreator: Connecting
AppPkgCreator: Sending packaging request
AppPkgCreator: Disconnecting
AppPkgCreator: Failed to close socket: [Errno 9] Bad file descriptor
{'Output': {'app_pkg_creator_summary_result': {'data': {'identifier': 'com.apple.sh',
                                                        'pkg_path': '~/Library/AutoPkg/Cache/com.github.fishd72.pkg.VisualVM/VisualVM-2.0.6.pkg',
                                                        'version': '2.0.6'},
                                               'report_fields': ['identifier',
                                                                 'version',
                                                                 'pkg_path'],
                                               'summary_text': 'The following '
                                                               'packages were '
                                                               'built:'},
            'new_package_request': True,
            'version': '2.0.6'}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.fishd72.pkg.VisualVM/receipts/VisualVM.pkg-receipt-20210213-232525.plist

The following packages were built:
    Identifier    Version  Pkg Path                                                                                 
    ----------    -------  --------                                                                                 
    com.apple.sh  2.0.6    ~/Library/AutoPkg/Cache/com.github.fishd72.pkg.VisualVM/VisualVM-2.0.6.pkg  
```

## ✅ pgAdmin4/pgAdmin4.pkg.recipe

```
% /usr/local/bin/autopkg run -vvq repos/fishd72-recipes/pgAdmin4/pgAdmin4.pkg.recipe
Processing repos/fishd72-recipes/pgAdmin4/pgAdmin4.pkg.recipe...
URLTextSearcher
{'Input': {'re_pattern': 'href="(https://.*?/macos/)">pg',
           'request_headers': {'user-agent': 'Mozilla/5.0 (Macintosh; Intel '
                                             'Mac OS X 10.11; rv:46.0) '
                                             'Gecko/20100101 Firefox/46.0'},
           'url': 'https://www.pgadmin.org/download/pgadmin-4-macos/'}}
URLTextSearcher: No value supplied for result_output_var_name, setting default value of: match
URLTextSearcher: Found matching text (match): https://www.postgresql.org/ftp/pgadmin/pgadmin4/v4.30/macos/
{'Output': {'match': 'https://www.postgresql.org/ftp/pgadmin/pgadmin4/v4.30/macos/'}}
URLTextSearcher
{'Input': {'re_pattern': 'href="(https://.*?\\.dmg)"><',
           'request_headers': {'user-agent': 'Mozilla/5.0 (Macintosh; Intel '
                                             'Mac OS X 10.11; rv:46.0) '
                                             'Gecko/20100101 Firefox/46.0'},
           'result_output_var_name': 'match',
           'url': 'https://www.postgresql.org/ftp/pgadmin/pgadmin4/v4.30/macos/'}}
URLTextSearcher: Found matching text (match): https://ftp.postgresql.org/pub/pgadmin/pgadmin4/v4.30/macos/pgadmin4-4.30.dmg
{'Output': {'match': 'https://ftp.postgresql.org/pub/pgadmin/pgadmin4/v4.30/macos/pgadmin4-4.30.dmg'}}
URLDownloader
{'Input': {'CHECK_FILESIZE_ONLY': True,
           'request_headers': {'user-agent': 'Mozilla/5.0 (Macintosh; Intel '
                                             'Mac OS X 10.11; rv:46.0) '
                                             'Gecko/20100101 Firefox/46.0'},
           'url': 'https://ftp.postgresql.org/pub/pgadmin/pgadmin4/v4.30/macos/pgadmin4-4.30.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.fishd72.pkg.pgAdmin4/downloads/pgadmin4-4.30.dmg
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.fishd72.pkg.pgAdmin4/downloads/pgadmin4-4.30.dmg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.fishd72.pkg.pgAdmin4/downloads/pgadmin4-4.30.dmg/pgAdmin '
                         '4.app',
           'requirement': 'identifier "Developer Bundle Identifier '
                          '(pgadmin4-4)" and anchor apple generic and '
                          'certificate 1[field.1.2.840.113635.100.6.2.6] /* '
                          'exists */ and certificate '
                          'leaf[field.1.2.840.113635.100.6.1.13] /* exists */ '
                          'and certificate leaf[subject.OU] = "26QKX55P9K"'}}
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.fishd72.pkg.pgAdmin4/downloads/pgadmin4-4.30.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.ht7s7d/pgAdmin 4.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.ht7s7d/pgAdmin 4.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.ht7s7d/pgAdmin 4.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
AppPkgCreator
{'Input': {}}
AppPkgCreator: Mounted disk image ~/Library/AutoPkg/Cache/com.github.fishd72.pkg.pgAdmin4/downloads/pgadmin4-4.30.dmg
AppPkgCreator: Using path '/private/tmp/dmg.P5jM5q/pgAdmin 4.app' matched from globbed '/private/tmp/dmg.P5jM5q/*.app'.
AppPkgCreator: Version: 4.30.0
AppPkgCreator: BundleID: org.pgadmin.pgAdmin4
AppPkgCreator: Package already exists at path ~/Library/AutoPkg/Cache/com.github.fishd72.pkg.pgAdmin4/pgAdmin 4-4.30.0.pkg.
AppPkgCreator: Existing package matches version and identifier, not building.
{'Output': {'version': '4.30.0'}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.fishd72.pkg.pgAdmin4/receipts/pgAdmin4.pkg-receipt-20210213-232648.plist

Nothing downloaded, packaged or imported.
```

