### PR TITLE
Brave AppPkgCreator Tweak

### DIFF
--- a/Brave/Brave.pkg.recipe
+++ b/Brave/Brave.pkg.recipe
@@ -13,7 +13,7 @@
 		<key>APP_FILENAME</key>
 		<string>Brave</string>
 		<key>NAME</key>
-		<string>Brave</string>
+		<string>BraveBrowser</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>1.0.0</string>
@@ -24,6 +24,11 @@
 		<dict>
 			<key>Processor</key>
 			<string>AppPkgCreator</string>
+			<key>Arguments</key>
+			<dict>
+				<key>pkg_path</key>
+				<string>%RECIPE_CACHE_DIR%/%NAME%-%version%.pkg</string>
+			</dict>
 		</dict>
 	</array>
 </dict>


### PR DESCRIPTION
Modified AppPkgCreator arguments to honor the %NAME% variable as most PKG recipes do.

produces a package by default BraveBrowser-1.43.89.0.pkg instead of "Brave Browser-1.43.89.0.pkg" (with the space from the app name).

Honors any name variable changes from overrides (which I need for my own workflow).