### PR TITLE
Adding custom pkg_path key so that the %PLATFORM% input is reflected in pkg filename

### DIFF
--- a/IDEA-IU/IDEA-IU.pkg.recipe
+++ b/IDEA-IU/IDEA-IU.pkg.recipe
@@ -23,7 +23,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>pkg_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%-%PLATFORM_ARCH%-%version%.pkg</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%-%PLATFORM%-%version%.pkg</string>
 			</dict>
 			<key>Processor</key>
 			<string>AppPkgCreator</string>

--- a/IDEA-IU/IDEA-IU.pkg.recipe
+++ b/IDEA-IU/IDEA-IU.pkg.recipe
@@ -20,6 +20,11 @@
 	<key>Process</key>
 	<array>
 		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>pkg_path</key>
+				<string>%RECIPE_CACHE_DIR%/%NAME%-%PLATFORM_ARCH%-%version%.pkg</string>
+			</dict>
 			<key>Processor</key>
 			<string>AppPkgCreator</string>
 		</dict>


### PR DESCRIPTION
I added an argument to the AppPkgCreator processor so that it adds the %PLATFORM% key into the pkg filename. 

This is so that we can have two overrides running and uploading to Jamf, one for Intel, one for Apple Silicon, that we can easily distinguish from each other. 