### PR TITLE
Update visualvm.download.recipe

### DIFF
--- a/VisualVM/visualvm.download.recipe
+++ b/VisualVM/visualvm.download.recipe
@@ -49,7 +49,7 @@
 				<key>input_path</key>
 				<string>%pathname%/VisualVM.app</string>
 				<key>requirement</key>
-				<string>identifier VisualVM and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = VB5E2TV963</string>
+				<string>identifier io.visualvm.VisualVM and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = VB5E2TV963</string>
 			</dict>
 			<key>Processor</key>
 			<string>CodeSignatureVerifier</string>


### PR DESCRIPTION
Changing dev signing certificate identifier to match new value as per issue #10
Before change:
```
% autopkg run -vvv /Users/Darren.Wallace/Desktop/visualvm.download.recipe 
Processing /Users/Darren.Wallace/Desktop/visualvm.download.recipe...
WARNING: /Users/Darren.Wallace/Desktop/visualvm.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
{'AUTOPKG_VERSION': '2.7.2',
 'GITHUB_REPO': 'oracle/visualvm',
 'NAME': 'VisualVM',
 'PARENT_RECIPES': [],
 'RECIPE_CACHE_DIR': '/Users/Darren.Wallace/Library/AutoPkg/Cache/com.github.fishd72.download.VisualVM',
 'RECIPE_DIR': '/Users/Darren.Wallace/Desktop',
 'RECIPE_OVERRIDE_DIRS': ['~/Library/AutoPkg/RecipeOverrides'],
 'RECIPE_PATH': '/Users/Darren.Wallace/Desktop/visualvm.download.recipe',
 'RECIPE_REPOS': {'REDACTED}},
 'RECIPE_SEARCH_DIRS': ['REDACTED],
 'verbose': 3}
GitHubReleasesInfoProvider
{'Input': {'asset_regex': 'VisualVM_[\\S]+\\.dmg',
           'github_repo': 'oracle/visualvm'}}
GitHubReleasesInfoProvider: No value supplied for CURL_PATH, setting default value of: /usr/bin/curl
GitHubReleasesInfoProvider: No value supplied for GITHUB_URL, setting default value of: https://api.github.com
GitHubReleasesInfoProvider: No value supplied for GITHUB_TOKEN_PATH, setting default value of: ~/.autopkg_gh_token
GitHubReleasesInfoProvider: Matched regex 'VisualVM_[\S]+\.dmg' among asset(s): nb190_platform_20231030.zip, org-graalvm-visualvm-jfr-streaming.nbm, VisualVM_218.dmg, visualvm_218.zip
GitHubReleasesInfoProvider: Selected asset 'VisualVM_218.dmg' from release 'VisualVM 2.1.8'
{'Output': {'asset_created_at': '2024-03-18T09:40:22Z',
            'asset_url': 'https://api.github.com/repos/oracle/visualvm/releases/assets/157257075',
            'url': 'https://github.com/oracle/visualvm/releases/download/2.1.8/VisualVM_218.dmg',
            'version': '2.1.8'}}
URLDownloader
{'Input': {'filename': 'VisualVM-2.1.8.dmg',
           'url': 'https://github.com/oracle/visualvm/releases/download/2.1.8/VisualVM_218.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing /Users/Darren.Wallace/Library/AutoPkg/Cache/com.github.fishd72.download.VisualVM/downloads/VisualVM-2.1.8.dmg
{'Output': {'pathname': '/Users/Darren.Wallace/Library/AutoPkg/Cache/com.github.fishd72.download.VisualVM/downloads/VisualVM-2.1.8.dmg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '/Users/Darren.Wallace/Library/AutoPkg/Cache/com.github.fishd72.download.VisualVM/downloads/VisualVM-2.1.8.dmg/VisualVM.app',
           'requirement': 'identifier VisualVM and anchor apple generic and '
                          'certificate 1[field.1.2.840.113635.100.6.2.6] /* '
                          'exists */ and certificate '
                          'leaf[field.1.2.840.113635.100.6.1.13] /* exists */ '
                          'and certificate leaf[subject.OU] = VB5E2TV963'}}
CodeSignatureVerifier: Mounted disk image /Users/Darren.Wallace/Library/AutoPkg/Cache/com.github.fishd72.download.VisualVM/downloads/VisualVM-2.1.8.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.HQ50GB/VisualVM.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.HQ50GB/VisualVM.app: satisfies its Designated Requirement
CodeSignatureVerifier: test-requirement: code failed to satisfy specified code requirement(s)
Traceback (most recent call last):
  File "/Library/AutoPkg/autopkglib/__init__.py", line 840, in process
    self.env = processor.process()
  File "/Library/AutoPkg/autopkglib/__init__.py", line 626, in process
    self.main()
  File "/Library/AutoPkg/autopkglib/CodeSignatureVerifier.py", line 351, in main
    self.process_code_signature(matched_input_path)
  File "/Library/AutoPkg/autopkglib/CodeSignatureVerifier.py", line 239, in process_code_signature
    raise ProcessorError(
autopkglib.ProcessorError: Code signature verification failed. Note that all verifications can be disabled by setting the variable DISABLE_CODE_SIGNATURE_VERIFICATION to a non-empty value.
  File "/Library/AutoPkg/autopkglib/__init__.py", line 840, in process
    self.env = processor.process()
Code signature verification failed. Note that all verifications can be disabled by setting the variable DISABLE_CODE_SIGNATURE_VERIFICATION to a non-empty value.
Failed.
Receipt written to /Users/Darren.Wallace/Library/AutoPkg/Cache/com.github.fishd72.download.VisualVM/receipts/visualvm.download-receipt-20240320-075709.plist

The following recipes failed:
    /Users/Darren.Wallace/Desktop/visualvm.download.recipe
        Error in com.github.fishd72.download.VisualVM: Processor: CodeSignatureVerifier: Error: Code signature verification failed. Note that all verifications can be disabled by setting the variable DISABLE_CODE_SIGNATURE_VERIFICATION to a non-empty value.

Nothing downloaded, packaged or imported.
% 
```

New Download values:
```
% codesign --display -r- /Volumes/VisualVM\ 2.1.8/VisualVM.app 
Executable=/Volumes/VisualVM 2.1.8/VisualVM.app/Contents/MacOS/visualvm
designated => identifier "io.visualvm.VisualVM" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = VB5E2TV963

    1. SHA-256             : 31053b63156b75a02c7d80e7943f0517c0c35bcf14b399b646492304ae6ce5cd
       SHA-1               : 65d7edaaffdc2b3367a193a06fe4593b04829a97
       Common Name         : Developer ID Application: Oracle America, Inc. (VB5E2TV963)
       Organization        : Oracle America, Inc.
       Organizational Unit : VB5E2TV963
       Valid From          : 2022/04/04 15:59:15 +0100
       Valid Until         : 2027/02/01 22:12:15 +0000
```

After change:
```
% autopkg run -vvv /Users/Darren.Wallace/Desktop/visualvm.download.recipe 
Processing /Users/Darren.Wallace/Desktop/visualvm.download.recipe...
WARNING: /Users/Darren.Wallace/Desktop/visualvm.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
{'AUTOPKG_VERSION': '2.7.2',
 'GITHUB_REPO': 'oracle/visualvm',
 'NAME': 'VisualVM',
 'PARENT_RECIPES': [],
 'RECIPE_CACHE_DIR': '/Users/Darren.Wallace/Library/AutoPkg/Cache/com.github.fishd72.download.VisualVM',
 'RECIPE_DIR': '/Users/Darren.Wallace/Desktop',
 'RECIPE_OVERRIDE_DIRS': ['~/Library/AutoPkg/RecipeOverrides'],
 'RECIPE_PATH': '/Users/Darren.Wallace/Desktop/visualvm.download.recipe',
 'RECIPE_REPOS': {REDACTED}},
 'RECIPE_SEARCH_DIRS': ['REDACTED,
 'verbose': 3}
GitHubReleasesInfoProvider
{'Input': {'asset_regex': 'VisualVM_[\\S]+\\.dmg',
           'github_repo': 'oracle/visualvm'}}
GitHubReleasesInfoProvider: No value supplied for CURL_PATH, setting default value of: /usr/bin/curl
GitHubReleasesInfoProvider: No value supplied for GITHUB_URL, setting default value of: https://api.github.com
GitHubReleasesInfoProvider: No value supplied for GITHUB_TOKEN_PATH, setting default value of: ~/.autopkg_gh_token
GitHubReleasesInfoProvider: Matched regex 'VisualVM_[\S]+\.dmg' among asset(s): nb190_platform_20231030.zip, org-graalvm-visualvm-jfr-streaming.nbm, VisualVM_218.dmg, visualvm_218.zip
GitHubReleasesInfoProvider: Selected asset 'VisualVM_218.dmg' from release 'VisualVM 2.1.8'
{'Output': {'asset_created_at': '2024-03-18T09:40:22Z',
            'asset_url': 'https://api.github.com/repos/oracle/visualvm/releases/assets/157257075',
            'url': 'https://github.com/oracle/visualvm/releases/download/2.1.8/VisualVM_218.dmg',
            'version': '2.1.8'}}
URLDownloader
{'Input': {'filename': 'VisualVM-2.1.8.dmg',
           'url': 'https://github.com/oracle/visualvm/releases/download/2.1.8/VisualVM_218.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing /Users/Darren.Wallace/Library/AutoPkg/Cache/com.github.fishd72.download.VisualVM/downloads/VisualVM-2.1.8.dmg
{'Output': {'pathname': '/Users/Darren.Wallace/Library/AutoPkg/Cache/com.github.fishd72.download.VisualVM/downloads/VisualVM-2.1.8.dmg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '/Users/Darren.Wallace/Library/AutoPkg/Cache/com.github.fishd72.download.VisualVM/downloads/VisualVM-2.1.8.dmg/VisualVM.app',
           'requirement': 'identifier io.visualvm.VisualVM and anchor apple '
                          'generic and certificate '
                          '1[field.1.2.840.113635.100.6.2.6] /* exists */ and '
                          'certificate leaf[field.1.2.840.113635.100.6.1.13] '
                          '/* exists */ and certificate leaf[subject.OU] = '
                          'VB5E2TV963'}}
CodeSignatureVerifier: Mounted disk image /Users/Darren.Wallace/Library/AutoPkg/Cache/com.github.fishd72.download.VisualVM/downloads/VisualVM-2.1.8.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.IoI1fV/VisualVM.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.IoI1fV/VisualVM.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.IoI1fV/VisualVM.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
Versioner
{'Input': {'input_plist_path': '/Users/Darren.Wallace/Library/AutoPkg/Cache/com.github.fishd72.download.VisualVM/downloads/VisualVM-2.1.8.dmg/VisualVM.app/Contents/Info.plist',
           'plist_version_key': 'CFBundleShortVersionString'}}
Versioner: No value supplied for skip_single_root_dir, setting default value of: False
Versioner: Mounted disk image /Users/Darren.Wallace/Library/AutoPkg/Cache/com.github.fishd72.download.VisualVM/downloads/VisualVM-2.1.8.dmg
Versioner: Found version 2.1.8 in file /Users/Darren.Wallace/Library/AutoPkg/Cache/com.github.fishd72.download.VisualVM/downloads/VisualVM-2.1.8.dmg/VisualVM.app/Contents/Info.plist
{'Output': {'version': '2.1.8'}}
{'AUTOPKG_VERSION': '2.7.2',
 'CHECK_FILESIZE_ONLY': False,
 'CURL_PATH': '/usr/bin/curl',
 'GITHUB_REPO': 'oracle/visualvm',
 'GITHUB_TOKEN_PATH': '~/.autopkg_gh_token',
 'GITHUB_URL': 'https://api.github.com',
 'NAME': 'VisualVM',
 'PARENT_RECIPES': [],
 'RECIPE_CACHE_DIR': '/Users/Darren.Wallace/Library/AutoPkg/Cache/com.github.fishd72.download.VisualVM',
 'RECIPE_DIR': '/Users/Darren.Wallace/Desktop',
 'RECIPE_OVERRIDE_DIRS': ['~/Library/AutoPkg/RecipeOverrides'],
 'RECIPE_PATH': '/Users/Darren.Wallace/Desktop/visualvm.download.recipe',
 'RECIPE_REPOS': {REDACTED}},
 'RECIPE_SEARCH_DIRS': ['REDACTED],
 'asset_created_at': '2024-03-18T09:40:22Z',
 'asset_regex': 'VisualVM_[\\S]+\\.dmg',
 'asset_url': 'https://api.github.com/repos/oracle/visualvm/releases/assets/157257075',
 'download_changed': False,
 'etag': '',
 'filename': 'VisualVM-2.1.8.dmg',
 'github_repo': 'oracle/visualvm',
 'input_path': '/Users/Darren.Wallace/Library/AutoPkg/Cache/com.github.fishd72.download.VisualVM/downloads/VisualVM-2.1.8.dmg/VisualVM.app',
 'input_plist_path': '/Users/Darren.Wallace/Library/AutoPkg/Cache/com.github.fishd72.download.VisualVM/downloads/VisualVM-2.1.8.dmg/VisualVM.app/Contents/Info.plist',
 'last_modified': '',
 'pathname': '/Users/Darren.Wallace/Library/AutoPkg/Cache/com.github.fishd72.download.VisualVM/downloads/VisualVM-2.1.8.dmg',
 'plist_version_key': 'CFBundleShortVersionString',
 'prefetch_filename': False,
 'release_notes': '',
 'requirement': 'identifier io.visualvm.VisualVM and anchor apple generic and '
                'certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ '
                'and certificate leaf[field.1.2.840.113635.100.6.1.13] /* '
                'exists */ and certificate leaf[subject.OU] = VB5E2TV963',
 'skip_single_root_dir': False,
 'url': 'https://github.com/oracle/visualvm/releases/download/2.1.8/VisualVM_218.dmg',
 'verbose': 3,
 'version': '2.1.8'}
Receipt written to /Users/Darren.Wallace/Library/AutoPkg/Cache/com.github.fishd72.download.VisualVM/receipts/visualvm.download-receipt-20240320-080011.plist

Nothing downloaded, packaged or imported.
```
