### PR TITLE
Deprecate Twitch app

### DIFF
--- a/Curse, Inc./Twitch.download.recipe
+++ b/Curse, Inc./Twitch.download.recipe
@@ -20,6 +20,15 @@
 	<key>Process</key>
 	<array>
 		<dict>
+			<key>Processor</key>
+			<string>DeprecationWarning</string>
+			<key>Arguments</key>
+			<dict>
+				<key>warning_message</key>
+				<string>The Twitch Desktop app has been discontinued (details: https://www.makeuseof.com/why-twitch-killing-desktop-app/). This recipe is deprecated and will be removed in the future.</string>
+			</dict>
+		</dict>
+		<dict>
 			<key>Arguments</key>
 			<dict>
 				<key>filename</key>


### PR DESCRIPTION
Twitch Desktop is no longer available ([details](https://www.makeuseof.com/why-twitch-killing-desktop-app/)). This PR deprecates the Twitch recipes.
