### PR TITLE
Fix MongoDB Compass recipes

### DIFF
--- a/MongoDBCompassCommunity/MongoDBCompassCommunity.download.recipe
+++ b/MongoDBCompassCommunity/MongoDBCompassCommunity.download.recipe
@@ -5,37 +5,37 @@
 	<key>Comment</key>
 	<string>Created with Recipe Robot v1.0.5 (https://github.com/homebysix/recipe-robot)</string>
 	<key>Description</key>
-	<string>Downloads the latest version of MongoDB Compass Community.</string>
+	<string>Downloads the latest version of MongoDB Compass Community.
+	
+Valid values for ARCH include:
+- "x64" (default, Intel)
+- "arm64" (Apple Silicon)
+</string>
 	<key>Identifier</key>
 	<string>com.github.fishd72.download.MongoDBCompassCommunity</string>
 	<key>Input</key>
 	<dict>
 		<key>NAME</key>
 		<string>MongoDB Compass Community</string>
-		<key>MONGOPATTERN</key>
-		<string>https:\/\/downloads\.mongodb\.com\/compass\/mongodb-compass-community-[\S]+-darwin-x64\.dmg</string>
+		<key>ARCH</key>
+		<string>x64</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>1.0.0</string>
 	<key>Process</key>
 	<array>
+	<dict>
+		<key>Processor</key>
+		<string>GitHubReleasesInfoProvider</string>
+		<key>Arguments</key>
 		<dict>
-			<key>Processor</key>
-			<string>URLTextSearcher</string>
-			<key>Arguments</key>
-			<dict>
-				<key>url</key>
-				<string>https://www.mongodb.com/download-center/compass</string>
-				<key>re_pattern</key>
-				<string>%MONGOPATTERN%</string>
-			</dict>
+			<key>github_repo</key>
+			<string>mongodb-js/compass</string>
+			<key>asset_regex</key>
+			<string>mongodb-compass-[\d\.]+-darwin-%ARCH%\.dmg</string>
 		</dict>
+	</dict>
 		<dict>
-			<key>Arguments</key>
-			<dict>
-				<key>url</key>
-				<string>%match%</string>
-			</dict>
 			<key>Processor</key>
 			<string>URLDownloader</string>
 		</dict>
@@ -47,9 +47,9 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_path</key>
-				<string>%pathname%/MongoDB Compass Community.app</string>
+				<string>%pathname%/MongoDB Compass.app</string>
 				<key>requirement</key>
-				<string>identifier "com.mongodb.compass-community" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "4XWMY46275"</string>
+				<string>identifier "com.mongodb.compass" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "4XWMY46275"</string>
 			</dict>
 			<key>Processor</key>
 			<string>CodeSignatureVerifier</string>
@@ -58,7 +58,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_plist_path</key>
-				<string>%pathname%/MongoDB Compass Community.app/Contents/Info.plist</string>
+				<string>%pathname%/MongoDB Compass.app/Contents/Info.plist</string>
 				<key>plist_version_key</key>
 				<string>CFBundleShortVersionString</string>
 			</dict>

--- a/MongoDBCompassCommunity/MongoDBCompassCommunity.install.recipe
+++ b/MongoDBCompassCommunity/MongoDBCompassCommunity.install.recipe
@@ -30,7 +30,7 @@
 						<key>destination_path</key>
 						<string>/Applications</string>
 						<key>source_item</key>
-						<string>MongoDB Compass Community.app</string>
+						<string>MongoDB Compass.app</string>
 					</dict>
 				</array>
 			</dict>


### PR DESCRIPTION
This PR updates the download method and code signature requirement for MongoDB Compass.

Verbose recipe run output:

```
% autopkg run -vvq 'MongoDBCompassCommunity/MongoDBCompassCommunity.download.recipe'
Processing MongoDBCompassCommunity/MongoDBCompassCommunity.download.recipe...
WARNING: MongoDBCompassCommunity/MongoDBCompassCommunity.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
GitHubReleasesInfoProvider
{'Input': {'asset_regex': 'mongodb-compass-[\\d\\.]+-darwin-x64\\.dmg',
           'github_repo': 'mongodb-js/compass'}}
GitHubReleasesInfoProvider: No value supplied for CURL_PATH, setting default value of: /usr/bin/curl
GitHubReleasesInfoProvider: No value supplied for GITHUB_URL, setting default value of: https://api.github.com
GitHubReleasesInfoProvider: No value supplied for GITHUB_TOKEN_PATH, setting default value of: ~/.autopkg_gh_token
GitHubReleasesInfoProvider: Matched regex 'mongodb-compass-[\d\.]+-darwin-x64\.dmg' among asset(s): manifest.json, mongodb-compass-1.45.0-darwin-arm64.dmg, mongodb-compass-1.45.0-darwin-arm64.zip, mongodb-compass-1.45.0-darwin-arm64.zip.sig, mongodb-compass-1.45.0-darwin-x64.dmg, mongodb-compass-1.45.0-darwin-x64.zip, mongodb-compass-1.45.0-darwin-x64.zip.sig, mongodb-compass-1.45.0-linux-x64.tar.gz, mongodb-compass-1.45.0-linux-x64.tar.gz.sig, mongodb-compass-1.45.0-rhel-x64.tar.gz, mongodb-compass-1.45.0-rhel-x64.tar.gz.sig, mongodb-compass-1.45.0-win32-x64.exe, mongodb-compass-1.45.0-win32-x64.msi, mongodb-compass-1.45.0-win32-x64.zip, mongodb-compass-1.45.0-win32-x64.zip.sig, mongodb-compass-1.45.0.x86_64.rpm, mongodb-compass-isolated-1.45.0-darwin-arm64.dmg, mongodb-compass-isolated-1.45.0-darwin-arm64.zip, mongodb-compass-isolated-1.45.0-darwin-arm64.zip.sig, mongodb-compass-isolated-1.45.0-darwin-x64.dmg, mongodb-compass-isolated-1.45.0-darwin-x64.zip, mongodb-compass-isolated-1.45.0-darwin-x64.zip.sig, mongodb-compass-isolated-1.45.0-linux-x64.tar.gz, mongodb-compass-isolated-1.45.0-linux-x64.tar.gz.sig, mongodb-compass-isolated-1.45.0-rhel-x64.tar.gz, mongodb-compass-isolated-1.45.0-rhel-x64.tar.gz.sig, mongodb-compass-isolated-1.45.0-win32-x64.exe, mongodb-compass-isolated-1.45.0-win32-x64.msi, mongodb-compass-isolated-1.45.0-win32-x64.zip, mongodb-compass-isolated-1.45.0-win32-x64.zip.sig, mongodb-compass-isolated-1.45.0.x86_64.rpm, mongodb-compass-isolated-RELEASES, mongodb-compass-isolated_1.45.0_amd64.deb, mongodb-compass-isolated_1.45.0_amd64.deb.sig, mongodb-compass-readonly-1.45.0-darwin-arm64.dmg, mongodb-compass-readonly-1.45.0-darwin-arm64.zip, mongodb-compass-readonly-1.45.0-darwin-arm64.zip.sig, mongodb-compass-readonly-1.45.0-darwin-x64.dmg, mongodb-compass-readonly-1.45.0-darwin-x64.zip, mongodb-compass-readonly-1.45.0-darwin-x64.zip.sig, mongodb-compass-readonly-1.45.0-linux-x64.tar.gz, mongodb-compass-readonly-1.45.0-linux-x64.tar.gz.sig, mongodb-compass-readonly-1.45.0-rhel-x64.tar.gz, mongodb-compass-readonly-1.45.0-rhel-x64.tar.gz.sig, mongodb-compass-readonly-1.45.0-win32-x64.exe, mongodb-compass-readonly-1.45.0-win32-x64.msi, mongodb-compass-readonly-1.45.0-win32-x64.zip, mongodb-compass-readonly-1.45.0-win32-x64.zip.sig, mongodb-compass-readonly-1.45.0.x86_64.rpm, mongodb-compass-readonly-RELEASES, mongodb-compass-readonly_1.45.0_amd64.deb, mongodb-compass-readonly_1.45.0_amd64.deb.sig, mongodb-compass-RELEASES, mongodb-compass_1.45.0_amd64.deb, mongodb-compass_1.45.0_amd64.deb.sig, MongoDBCompass-1.45.0-full.nupkg, MongoDBCompass-1.45.0-full.nupkg.sig, MongoDBCompassIsolatedEdition-1.45.0-full.nupkg, MongoDBCompassIsolatedEdition-1.45.0-full.nupkg.sig, MongoDBCompassReadonly-1.45.0-full.nupkg, MongoDBCompassReadonly-1.45.0-full.nupkg.sig
GitHubReleasesInfoProvider: Selected asset 'mongodb-compass-1.45.0-darwin-x64.dmg' from release '1.45.0'
{'Output': {'asset_created_at': '2024-12-03T20:58:21Z',
            'asset_url': 'https://api.github.com/repos/mongodb-js/compass/releases/assets/210829781',
            'release_notes': 'Release v1.45.0\r\n'
                             '\r\n'
                             '\r\n'
                             "## What's Changed\r\n"
                             '### Bug Fixes\r\n'
                             '* fix(data-service): disable utf8 validation '
                             'when retrieving metadata compass needs in order '
                             'to function COMPASS-8517\n'
                             '\r\n'
                             '\r\n'
                             '**Full Changelog**: '
                             'https://github.com/mongodb-js/compass/compare/v1.44.7...v1.45.0\n',
            'url': 'https://github.com/mongodb-js/compass/releases/download/v1.45.0/mongodb-compass-1.45.0-darwin-x64.dmg',
            'version': '1.45.0'}}
URLDownloader
{'Input': {'url': 'https://github.com/mongodb-js/compass/releases/download/v1.45.0/mongodb-compass-1.45.0-darwin-x64.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Tue, 03 Dec 2024 20:58:24 GMT
URLDownloader: Storing new ETag header: "0x8DD13DD3A7CD13B"
URLDownloader: Downloaded ~/Library/AutoPkg/Cache/com.github.fishd72.download.MongoDBCompassCommunity/downloads/mongodb-compass-1.45.0-darwin-x64.dmg
{'Output': {'download_changed': True,
            'etag': '"0x8DD13DD3A7CD13B"',
            'last_modified': 'Tue, 03 Dec 2024 20:58:24 GMT',
            'pathname': '~/Library/AutoPkg/Cache/com.github.fishd72.download.MongoDBCompassCommunity/downloads/mongodb-compass-1.45.0-darwin-x64.dmg',
            'url_downloader_summary_result': {'data': {'download_path': '~/Library/AutoPkg/Cache/com.github.fishd72.download.MongoDBCompassCommunity/downloads/mongodb-compass-1.45.0-darwin-x64.dmg'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.fishd72.download.MongoDBCompassCommunity/downloads/mongodb-compass-1.45.0-darwin-x64.dmg/MongoDB '
                         'Compass.app',
           'requirement': 'identifier "com.mongodb.compass" and anchor apple '
                          'generic and certificate '
                          '1[field.1.2.840.113635.100.6.2.6] /* exists */ and '
                          'certificate leaf[field.1.2.840.113635.100.6.1.13] '
                          '/* exists */ and certificate leaf[subject.OU] = '
                          '"4XWMY46275"'}}
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.fishd72.download.MongoDBCompassCommunity/downloads/mongodb-compass-1.45.0-darwin-x64.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.vDyUnS/MongoDB Compass.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.vDyUnS/MongoDB Compass.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.vDyUnS/MongoDB Compass.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
Versioner
{'Input': {'input_plist_path': '~/Library/AutoPkg/Cache/com.github.fishd72.download.MongoDBCompassCommunity/downloads/mongodb-compass-1.45.0-darwin-x64.dmg/MongoDB '
                               'Compass.app/Contents/Info.plist',
           'plist_version_key': 'CFBundleShortVersionString'}}
Versioner: No value supplied for skip_single_root_dir, setting default value of: False
Versioner: Mounted disk image ~/Library/AutoPkg/Cache/com.github.fishd72.download.MongoDBCompassCommunity/downloads/mongodb-compass-1.45.0-darwin-x64.dmg
Versioner: Found version 1.45.0 in file ~/Library/AutoPkg/Cache/com.github.fishd72.download.MongoDBCompassCommunity/downloads/mongodb-compass-1.45.0-darwin-x64.dmg/MongoDB Compass.app/Contents/Info.plist
{'Output': {'version': '1.45.0'}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.fishd72.download.MongoDBCompassCommunity/receipts/MongoDBCompassCommunity.download-receipt-20241225-150834.plist

The following new items were downloaded:
    Download Path
    -------------
    ~/Library/AutoPkg/Cache/com.github.fishd72.download.MongoDBCompassCommunity/downloads/mongodb-compass-1.45.0-darwin-x64.dmg
```
