### PR TITLE
Deprecate Ghost recipes

### DIFF
--- a/Ghost/Ghost.download.recipe
+++ b/Ghost/Ghost.download.recipe
@@ -19,6 +19,15 @@
 	<array>
 		<dict>
 			<key>Processor</key>
+			<string>DeprecationWarning</string>
+			<key>Arguments</key>
+			<dict>
+				<key>warning_message</key>
+				<string>The Ghost Desktop app is no longer available (details: https://forum.ghost.org/t/has-the-ghost-native-app-for-desktop-disappeared/16990). This recipe is deprecated and will be removed in the future.</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>Processor</key>
 			<string>GitHubReleasesInfoProvider</string>
 			<key>Arguments</key>
 			<dict>


### PR DESCRIPTION
This PR deprecates the Ghost Desktop recipes, since this software is no longer available ([details](https://forum.ghost.org/t/has-the-ghost-native-app-for-desktop-disappeared/16990)).
