### PR TITLE
Fix Freeplane recipes and add ARCH input variable

### DIFF
--- a/Freeplane/Freeplane.download.recipe
+++ b/Freeplane/Freeplane.download.recipe
@@ -3,19 +3,20 @@
 <plist version="1.0">
 	<dict>
 		<key>Description</key>
-		<string>Downloads the latest version of Freeplane.</string>
+		<string>Downloads the latest version of Freeplane.
+		
+Valid values for ARCH include:
+- "intel" (default, x86_64)
+- "apple" (arm64)
+</string>
 		<key>Identifier</key>
 		<string>com.github.fishd72.download.Freeplane</string>
 		<key>Input</key>
 		<dict>
-			<key>DOWNLOAD_URL</key>
-			<string>https://sourceforge.net/projects/freeplane/files/</string>
 			<key>NAME</key>
 			<string>Freeplane</string>
-			<key>MAJOR_OS_VERSION</key>
-			<string></string>
-			<key>SEARCH_PATTERN</key>
-			<string>href="(.*/projects/freeplane/files/freeplane%20stable/freeplane_app*\.dmg/download)"</string>
+			<key>ARCH</key>
+			<string>intel</string>
 		</dict>
 		<key>MinimumVersion</key>
 		<string>1.0.0</string>
@@ -25,7 +26,7 @@
 				<key>Arguments</key>
 				<dict>
 					<key>SOURCEFORGE_FILE_PATTERN</key>
-					<string>freeplane_app_jre-[\d.]*\.dmg</string>
+					<string>Freeplane-[\d\.]+-%ARCH%\.dmg</string>
 					<key>SOURCEFORGE_PROJECT_ID</key>
 					<integer>211069</integer>
 				</dict>
@@ -51,7 +52,7 @@
 					<key>input_path</key>
 					<string>%pathname%/Freeplane.app</string>
 					<key>requirement</key>
-					<string>identifier "org.freeplane.core" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = CSHVD99Y7K</string>
+					<string>identifier "org.freeplane.launcher" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = CSHVD99Y7K</string>
 				</dict>
 				<key>Processor</key>
 				<string>CodeSignatureVerifier</string>


### PR DESCRIPTION
This PR updates the Freeplane download method and adds support for multiple architectures. It also updates the code signature requirement.

Download recipe verbose run log with default Intel architecture:

```
% autopkg run -vvq 'Freeplane/Freeplane.download.recipe'
Processing Freeplane/Freeplane.download.recipe...
WARNING: Freeplane/Freeplane.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
com.github.jessepeterson.munki.GrandPerspective/SourceForgeURLProvider
{'Input': {'SOURCEFORGE_FILE_PATTERN': 'Freeplane-[\\d\\.]+-intel\\.dmg',
           'SOURCEFORGE_PROJECT_ID': 211069}}
SourceForgeURLProvider: File URL https://sourceforge.net/projects/freeplane/files/freeplane%20stable/archive/1.12.8/Freeplane-1.12.8-intel.dmg/download
{'Output': {'url': 'https://sourceforge.net/projects/freeplane/files/freeplane%20stable/archive/1.12.8/Freeplane-1.12.8-intel.dmg/download'}}
URLDownloader
{'Input': {'filename': 'Freeplane.dmg',
           'url': 'https://sourceforge.net/projects/freeplane/files/freeplane%20stable/archive/1.12.8/Freeplane-1.12.8-intel.dmg/download'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Sat, 07 Dec 2024 12:40:10 GMT
URLDownloader: Storing new ETag header: "6754422a-7f906a7"
URLDownloader: Downloaded ~/Library/AutoPkg/Cache/com.github.fishd72.download.Freeplane/downloads/Freeplane.dmg
{'Output': {'download_changed': True,
            'etag': '"6754422a-7f906a7"',
            'last_modified': 'Sat, 07 Dec 2024 12:40:10 GMT',
            'pathname': '~/Library/AutoPkg/Cache/com.github.fishd72.download.Freeplane/downloads/Freeplane.dmg',
            'url_downloader_summary_result': {'data': {'download_path': '~/Library/AutoPkg/Cache/com.github.fishd72.download.Freeplane/downloads/Freeplane.dmg'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.fishd72.download.Freeplane/downloads/Freeplane.dmg/Freeplane.app',
           'requirement': 'identifier "org.freeplane.launcher" and anchor '
                          'apple generic and certificate '
                          '1[field.1.2.840.113635.100.6.2.6] /* exists */ and '
                          'certificate leaf[field.1.2.840.113635.100.6.1.13] '
                          '/* exists */ and certificate leaf[subject.OU] = '
                          'CSHVD99Y7K'}}
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.fishd72.download.Freeplane/downloads/Freeplane.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.PPwHu7/Freeplane.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.PPwHu7/Freeplane.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.PPwHu7/Freeplane.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
Versioner
{'Input': {'input_plist_path': '~/Library/AutoPkg/Cache/com.github.fishd72.download.Freeplane/downloads/Freeplane.dmg/Freeplane.app/Contents/Info.plist',
           'plist_version_key': 'CFBundleShortVersionString'}}
Versioner: No value supplied for skip_single_root_dir, setting default value of: False
Versioner: Mounted disk image ~/Library/AutoPkg/Cache/com.github.fishd72.download.Freeplane/downloads/Freeplane.dmg
Versioner: Found version 1.12.8 in file ~/Library/AutoPkg/Cache/com.github.fishd72.download.Freeplane/downloads/Freeplane.dmg/Freeplane.app/Contents/Info.plist
{'Output': {'version': '1.12.8'}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.fishd72.download.Freeplane/receipts/Freeplane.download-receipt-20241225-135234.plist

The following new items were downloaded:
    Download Path
    -------------
    ~/Library/AutoPkg/Cache/com.github.fishd72.download.Freeplane/downloads/Freeplane.dmg
```

Download recipe verbose run log with Apple Silicon architecture:

```
% autopkg run -vvq 'Freeplane/Freeplane.download.recipe' -k ARCH=apple
Processing Freeplane/Freeplane.download.recipe...
WARNING: Freeplane/Freeplane.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
com.github.jessepeterson.munki.GrandPerspective/SourceForgeURLProvider
{'Input': {'SOURCEFORGE_FILE_PATTERN': 'Freeplane-[\\d\\.]+-apple\\.dmg',
           'SOURCEFORGE_PROJECT_ID': 211069}}
SourceForgeURLProvider: File URL https://sourceforge.net/projects/freeplane/files/freeplane%20stable/archive/1.12.8/Freeplane-1.12.8-apple.dmg/download
{'Output': {'url': 'https://sourceforge.net/projects/freeplane/files/freeplane%20stable/archive/1.12.8/Freeplane-1.12.8-apple.dmg/download'}}
URLDownloader
{'Input': {'filename': 'Freeplane.dmg',
           'url': 'https://sourceforge.net/projects/freeplane/files/freeplane%20stable/archive/1.12.8/Freeplane-1.12.8-apple.dmg/download'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Sat, 07 Dec 2024 12:40:32 GMT
URLDownloader: Storing new ETag header: "67544240-7c872cb"
URLDownloader: Downloaded ~/Library/AutoPkg/Cache/com.github.fishd72.download.Freeplane/downloads/Freeplane.dmg
{'Output': {'download_changed': True,
            'etag': '"67544240-7c872cb"',
            'last_modified': 'Sat, 07 Dec 2024 12:40:32 GMT',
            'pathname': '~/Library/AutoPkg/Cache/com.github.fishd72.download.Freeplane/downloads/Freeplane.dmg',
            'url_downloader_summary_result': {'data': {'download_path': '~/Library/AutoPkg/Cache/com.github.fishd72.download.Freeplane/downloads/Freeplane.dmg'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.fishd72.download.Freeplane/downloads/Freeplane.dmg/Freeplane.app',
           'requirement': 'identifier "org.freeplane.launcher" and anchor '
                          'apple generic and certificate '
                          '1[field.1.2.840.113635.100.6.2.6] /* exists */ and '
                          'certificate leaf[field.1.2.840.113635.100.6.1.13] '
                          '/* exists */ and certificate leaf[subject.OU] = '
                          'CSHVD99Y7K'}}
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.fishd72.download.Freeplane/downloads/Freeplane.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.GGibuS/Freeplane.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.GGibuS/Freeplane.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.GGibuS/Freeplane.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
Versioner
{'Input': {'input_plist_path': '~/Library/AutoPkg/Cache/com.github.fishd72.download.Freeplane/downloads/Freeplane.dmg/Freeplane.app/Contents/Info.plist',
           'plist_version_key': 'CFBundleShortVersionString'}}
Versioner: No value supplied for skip_single_root_dir, setting default value of: False
Versioner: Mounted disk image ~/Library/AutoPkg/Cache/com.github.fishd72.download.Freeplane/downloads/Freeplane.dmg
Versioner: Found version 1.12.8 in file ~/Library/AutoPkg/Cache/com.github.fishd72.download.Freeplane/downloads/Freeplane.dmg/Freeplane.app/Contents/Info.plist
{'Output': {'version': '1.12.8'}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.fishd72.download.Freeplane/receipts/Freeplane.download-receipt-20241225-135304.plist

The following new items were downloaded:
    Download Path
    -------------
    ~/Library/AutoPkg/Cache/com.github.fishd72.download.Freeplane/downloads/Freeplane.dmg
```

Pkg recipe verbose run log with default Intel architecture:

```
% autopkg run -vvq 'Freeplane/Freeplane.pkg.recipe'
Processing Freeplane/Freeplane.pkg.recipe...
WARNING: Freeplane/Freeplane.pkg.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
com.github.jessepeterson.munki.GrandPerspective/SourceForgeURLProvider
{'Input': {'SOURCEFORGE_FILE_PATTERN': 'Freeplane-[\\d\\.]+-intel\\.dmg',
           'SOURCEFORGE_PROJECT_ID': 211069}}
SourceForgeURLProvider: File URL https://sourceforge.net/projects/freeplane/files/freeplane%20stable/archive/1.12.8/Freeplane-1.12.8-intel.dmg/download
{'Output': {'url': 'https://sourceforge.net/projects/freeplane/files/freeplane%20stable/archive/1.12.8/Freeplane-1.12.8-intel.dmg/download'}}
URLDownloader
{'Input': {'filename': 'Freeplane.dmg',
           'url': 'https://sourceforge.net/projects/freeplane/files/freeplane%20stable/archive/1.12.8/Freeplane-1.12.8-intel.dmg/download'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Sat, 07 Dec 2024 12:40:10 GMT
URLDownloader: Storing new ETag header: "6754422a-7f906a7"
URLDownloader: Downloaded ~/Library/AutoPkg/Cache/com.github.fishd72.pkg.Freeplane/downloads/Freeplane.dmg
{'Output': {'download_changed': True,
            'etag': '"6754422a-7f906a7"',
            'last_modified': 'Sat, 07 Dec 2024 12:40:10 GMT',
            'pathname': '~/Library/AutoPkg/Cache/com.github.fishd72.pkg.Freeplane/downloads/Freeplane.dmg',
            'url_downloader_summary_result': {'data': {'download_path': '~/Library/AutoPkg/Cache/com.github.fishd72.pkg.Freeplane/downloads/Freeplane.dmg'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.fishd72.pkg.Freeplane/downloads/Freeplane.dmg/Freeplane.app',
           'requirement': 'identifier "org.freeplane.launcher" and anchor '
                          'apple generic and certificate '
                          '1[field.1.2.840.113635.100.6.2.6] /* exists */ and '
                          'certificate leaf[field.1.2.840.113635.100.6.1.13] '
                          '/* exists */ and certificate leaf[subject.OU] = '
                          'CSHVD99Y7K'}}
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.fishd72.pkg.Freeplane/downloads/Freeplane.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.xg9tfH/Freeplane.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.xg9tfH/Freeplane.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.xg9tfH/Freeplane.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
Versioner
{'Input': {'input_plist_path': '~/Library/AutoPkg/Cache/com.github.fishd72.pkg.Freeplane/downloads/Freeplane.dmg/Freeplane.app/Contents/Info.plist',
           'plist_version_key': 'CFBundleShortVersionString'}}
Versioner: No value supplied for skip_single_root_dir, setting default value of: False
Versioner: Mounted disk image ~/Library/AutoPkg/Cache/com.github.fishd72.pkg.Freeplane/downloads/Freeplane.dmg
Versioner: Found version 1.12.8 in file ~/Library/AutoPkg/Cache/com.github.fishd72.pkg.Freeplane/downloads/Freeplane.dmg/Freeplane.app/Contents/Info.plist
{'Output': {'version': '1.12.8'}}
AppPkgCreator
{'Input': {'pkg_path': '~/Library/AutoPkg/Cache/com.github.fishd72.pkg.Freeplane/Freeplane-1.12.8.pkg',
           'version': '1.12.8'}}
AppPkgCreator: Mounted disk image ~/Library/AutoPkg/Cache/com.github.fishd72.pkg.Freeplane/downloads/Freeplane.dmg
AppPkgCreator: Using path '/private/tmp/dmg.ZtwGk8/Freeplane.app' matched from globbed '/private/tmp/dmg.ZtwGk8/*.app'.
AppPkgCreator: BundleID: org.freeplane.launcher
AppPkgCreator: Copied /private/tmp/dmg.ZtwGk8/Freeplane.app to ~/Library/AutoPkg/Cache/com.github.fishd72.pkg.Freeplane/payload/Applications/Freeplane.app
AppPkgCreator: Connecting
AppPkgCreator: Sending packaging request
AppPkgCreator: Disconnecting
AppPkgCreator: Failed to close socket: [Errno 9] Bad file descriptor
{'Output': {'app_pkg_creator_summary_result': {'data': {'identifier': 'org.freeplane.launcher',
                                                        'pkg_path': '~/Library/AutoPkg/Cache/com.github.fishd72.pkg.Freeplane/Freeplane-1.12.8.pkg',
                                                        'version': '1.12.8'},
                                               'report_fields': ['identifier',
                                                                 'version',
                                                                 'pkg_path'],
                                               'summary_text': 'The following '
                                                               'packages were '
                                                               'built:'},
            'new_package_request': True,
            'version': '1.12.8'}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.fishd72.pkg.Freeplane/receipts/Freeplane.pkg-receipt-20241225-135350.plist

The following new items were downloaded:
    Download Path
    -------------
    ~/Library/AutoPkg/Cache/com.github.fishd72.pkg.Freeplane/downloads/Freeplane.dmg

The following packages were built:
    Identifier              Version  Pkg Path
    ----------              -------  --------
    org.freeplane.launcher  1.12.8   ~/Library/AutoPkg/Cache/com.github.fishd72.pkg.Freeplane/Freeplane-1.12.8.pkg
```

Pkg recipe verbose run log with Apple Silicon architecture:

```
% autopkg run -vvq 'Freeplane/Freeplane.pkg.recipe' -k ARCH=apple
Processing Freeplane/Freeplane.pkg.recipe...
WARNING: Freeplane/Freeplane.pkg.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
com.github.jessepeterson.munki.GrandPerspective/SourceForgeURLProvider
{'Input': {'SOURCEFORGE_FILE_PATTERN': 'Freeplane-[\\d\\.]+-apple\\.dmg',
           'SOURCEFORGE_PROJECT_ID': 211069}}
SourceForgeURLProvider: File URL https://sourceforge.net/projects/freeplane/files/freeplane%20stable/archive/1.12.8/Freeplane-1.12.8-apple.dmg/download
{'Output': {'url': 'https://sourceforge.net/projects/freeplane/files/freeplane%20stable/archive/1.12.8/Freeplane-1.12.8-apple.dmg/download'}}
URLDownloader
{'Input': {'filename': 'Freeplane.dmg',
           'url': 'https://sourceforge.net/projects/freeplane/files/freeplane%20stable/archive/1.12.8/Freeplane-1.12.8-apple.dmg/download'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Sat, 07 Dec 2024 12:40:32 GMT
URLDownloader: Storing new ETag header: "67544240-7c872cb"
URLDownloader: Downloaded ~/Library/AutoPkg/Cache/com.github.fishd72.pkg.Freeplane/downloads/Freeplane.dmg
{'Output': {'download_changed': True,
            'etag': '"67544240-7c872cb"',
            'last_modified': 'Sat, 07 Dec 2024 12:40:32 GMT',
            'pathname': '~/Library/AutoPkg/Cache/com.github.fishd72.pkg.Freeplane/downloads/Freeplane.dmg',
            'url_downloader_summary_result': {'data': {'download_path': '~/Library/AutoPkg/Cache/com.github.fishd72.pkg.Freeplane/downloads/Freeplane.dmg'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.fishd72.pkg.Freeplane/downloads/Freeplane.dmg/Freeplane.app',
           'requirement': 'identifier "org.freeplane.launcher" and anchor '
                          'apple generic and certificate '
                          '1[field.1.2.840.113635.100.6.2.6] /* exists */ and '
                          'certificate leaf[field.1.2.840.113635.100.6.1.13] '
                          '/* exists */ and certificate leaf[subject.OU] = '
                          'CSHVD99Y7K'}}
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.fishd72.pkg.Freeplane/downloads/Freeplane.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.vSph5L/Freeplane.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.vSph5L/Freeplane.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.vSph5L/Freeplane.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
Versioner
{'Input': {'input_plist_path': '~/Library/AutoPkg/Cache/com.github.fishd72.pkg.Freeplane/downloads/Freeplane.dmg/Freeplane.app/Contents/Info.plist',
           'plist_version_key': 'CFBundleShortVersionString'}}
Versioner: No value supplied for skip_single_root_dir, setting default value of: False
Versioner: Mounted disk image ~/Library/AutoPkg/Cache/com.github.fishd72.pkg.Freeplane/downloads/Freeplane.dmg
Versioner: Found version 1.12.8 in file ~/Library/AutoPkg/Cache/com.github.fishd72.pkg.Freeplane/downloads/Freeplane.dmg/Freeplane.app/Contents/Info.plist
{'Output': {'version': '1.12.8'}}
AppPkgCreator
{'Input': {'pkg_path': '~/Library/AutoPkg/Cache/com.github.fishd72.pkg.Freeplane/Freeplane-1.12.8.pkg',
           'version': '1.12.8'}}
AppPkgCreator: Mounted disk image ~/Library/AutoPkg/Cache/com.github.fishd72.pkg.Freeplane/downloads/Freeplane.dmg
AppPkgCreator: Using path '/private/tmp/dmg.pbXfds/Freeplane.app' matched from globbed '/private/tmp/dmg.pbXfds/*.app'.
AppPkgCreator: BundleID: org.freeplane.launcher
AppPkgCreator: Package already exists at path ~/Library/AutoPkg/Cache/com.github.fishd72.pkg.Freeplane/Freeplane-1.12.8.pkg.
AppPkgCreator: Existing package matches version and identifier, not building.
{'Output': {'version': '1.12.8'}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.fishd72.pkg.Freeplane/receipts/Freeplane.pkg-receipt-20241225-135405.plist

The following new items were downloaded:
    Download Path
    -------------
    ~/Library/AutoPkg/Cache/com.github.fishd72.pkg.Freeplane/downloads/Freeplane.dmg
```