### PR TITLE
Removal of unused `options` from PkgCreator arguments

### DIFF
--- a/AppCleaner/AppCleaner.pkg.recipe
+++ b/AppCleaner/AppCleaner.pkg.recipe
@@ -83,8 +83,6 @@
 						<string>%RECIPE_CACHE_DIR%</string>
 						<key>id</key>
 						<string>%BUNDLE_ID%</string>
-						<key>options</key>
-						<string>purge_ds_store</string>
 						<key>chown</key>
 						<array>
 							<dict>

--- a/Boostnote/Boostnote.pkg.recipe
+++ b/Boostnote/Boostnote.pkg.recipe
@@ -83,8 +83,6 @@
 					<string>%RECIPE_CACHE_DIR%</string>
 					<key>id</key>
 					<string>%BUNDLE_ID%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>chown</key>
 					<array>
 						<dict>

--- a/JD-GUI/JD-GUI.pkg.recipe
+++ b/JD-GUI/JD-GUI.pkg.recipe
@@ -99,8 +99,6 @@
 						<string>%RECIPE_CACHE_DIR%</string>
 						<key>id</key>
 						<string>%BUNDLE_ID%</string>
-						<key>options</key>
-						<string>purge_ds_store</string>
 						<key>chown</key>
 						<array>
 							<dict>

--- a/Miller/Miller.pkg.recipe
+++ b/Miller/Miller.pkg.recipe
@@ -63,8 +63,6 @@
 					<string>com.github.johnkerl.%NAME%</string>
 					<key>version</key>
 					<string>1.0</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>chown</key>
 					<array>
 						<dict>

--- a/Shuttle/Shuttle.pkg.recipe
+++ b/Shuttle/Shuttle.pkg.recipe
@@ -63,8 +63,6 @@
 					</array>
 					<key>id</key>
 					<string>%BUNDLE_ID%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgname</key>
 					<string>%NAME%-%version%</string>
 					<key>pkgroot</key>

--- a/ecs-cli/ecs-cli.pkg.recipe
+++ b/ecs-cli/ecs-cli.pkg.recipe
@@ -63,8 +63,6 @@
 					<string>com.amazon.%NAME%</string>
 					<key>version</key>
 					<string>1.0</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>chown</key>
 					<array>
 						<dict>


### PR DESCRIPTION
Hundreds of recipes dating from the very beginning of AutoPkg use the `options` key in the `pkg_request` argument of PkgCreator:

```xml
<key>options</key>
<string>purge_ds_store</string>
```

However, this key doesn't serve any purpose at all. The `options` key is ignored and not passed along to `pkgbuild`, regardless of its presence or contents. It appears that this has been the case since the very first public release of AutoPkg 0.1.0!

So this pull request (one of over 100) formally ends this practice and removes the unused and unneeded `options` key from all recipes in the AutoPkg org that use PkgCreator.

Thanks for considering!

_This PR was submitted using [Repo Lasso](https://github.com/homebysix/repo-lasso) v1.2.0._