### PR TITLE
20251122-fix-endofcheckphase

### DIFF
--- a/azcopy-cli/azcopy-cli.download.recipe
+++ b/azcopy-cli/azcopy-cli.download.recipe
@@ -17,7 +17,7 @@
       <key>ARCH</key>
       <string>-arm64</string>
       <key>VER_REGEX</key>
-      <string>^.*\/azcopy_darwin_a..64_([0-9.]+)\.zip</string> 
+      <string>^.*\/azcopy_darwin_a..64_([0-9.]+)\.zip</string>
     </dict>
     <key>Process</key>
     <array>
@@ -49,6 +49,10 @@
       </dict>
       <dict>
         <key>Processor</key>
+        <string>EndOfCheckPhase</string>
+      </dict>
+      <dict>
+        <key>Processor</key>
         <string>com.github.jazzace.processors/TextSearcher</string>
         <key>Arguments</key>
         <dict>
@@ -60,10 +64,6 @@
           <string>version</string>
         </dict>
       </dict>
-      <dict>
-        <key>Processor</key>
-        <string>EndOfCheckPhase</string>
-      </dict>
     </array>
-  </dict> 
+  </dict>
 </plist>


### PR DESCRIPTION
In order to use AutoPkg with the `--check` argument, download recipes must include an `EndOfCheckPhase` processor. This processor indicates where to stop processing when checking for new downloaded files. The proper placement of the processor is directly after the last `URLDownloader` or `URLDownloaderPython` processor to eliminate unnecessary processing (such as a code signature verification of an unchanged file).

This pull request adds the `EndOfCheckPhase` processor if is is missing and moves it to the correct location if it already exists.

Thanks for considering!

This PR was submitted using [Repo Lasso](https://github.com/homebysix/repo-lasso) v1.2.0.